### PR TITLE
Fixing Attachments Not Getting Set

### DIFF
--- a/models/template.go
+++ b/models/template.go
@@ -83,6 +83,14 @@ func GetTemplateByName(n string, uid int64) (Template, error) {
 	if err != nil {
 		Logger.Println(err)
 	}
+	err = db.Where("template_id=?", t.Id).Find(&t.Attachments).Error
+	if err != nil && err != gorm.RecordNotFound {
+		Logger.Println(err)
+		return t, err
+	}
+	if err == nil && len(t.Attachments) == 0 {
+		t.Attachments = make([]Attachment, 0)
+	}
 	return t, err
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -217,7 +217,6 @@ func SendTestEmail(s *models.SendTestEmailRequest) error {
 	e.To = []string{s.Email}
 	// Attach the files
 	for _, a := range s.Template.Attachments {
-		Logger.Printf("Attaching %s\n", a.Name)
 		decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(a.Content))
 		_, err = e.Attach(decoder, a.Name, a.Type)
 		if err != nil {


### PR DESCRIPTION
Attachments are now attached to emails (whoops!)
In addition, attachments are now fetched on `models.Template.GetTemplateByName`
Fixes #141 
