### PR TITLE
Added the ability to convert links on email import to point to the landing page

### DIFF
--- a/static/js/app/templates.js
+++ b/static/js/app/templates.js
@@ -230,15 +230,19 @@ function copy(idx) {
 
 function importEmail() {
     raw = $("#email_content").val()
+    convert_links = $("#convert_links_checkbox").prop("checked")
     if (!raw) {
         modalError("No Content Specified!")
     } else {
         $.ajax({
-                type: "POST",
+                method: "POST",
                 url: "/api/import/email",
-                data: raw,
+                data: JSON.stringify({
+                    content: raw,
+                    convert_links: convert_links
+                }),
                 dataType: "json",
-                contentType: "text/plain"
+                contentType: "application/json"
             })
             .success(function(data) {
                 $("#text_editor").val(data.text)

--- a/templates/templates.html
+++ b/templates/templates.html
@@ -140,6 +140,10 @@
             <div class="form-group">
                     <textarea rows="10" id="email_content" class="gophish-editor form-control" placeholder="Raw Email Source"></textarea>
             </div>
+	    <div class="checkbox checkbox-primary">
+                <input id="convert_links_checkbox" type="checkbox" checked>
+		<label for="convert_links_checkbox">Change Links to Point to Landing Page</label>
+            </div>
         </div>
         <div class="modal-footer">
             <button type="button" data-dismiss="modal" class="btn btn-default">Cancel</button>


### PR DESCRIPTION
This fixes #201. We now allow users to automatically change all links in an email to point to the landing page.
