### PR TITLE
Clean up templates

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,6 @@
     <title>{{ .Title }} - Gophish</title>
 
     <!-- Bootstrap core CSS -->
-    <!-- <link href="/css/bootstrap.css" rel="stylesheet"> -->
     <link href="/bootstrap/css/bootstrap.css" rel="stylesheet">
     <!-- Custom styles for this template -->
     <link href="/css/main.css" rel="stylesheet">

--- a/templates/login.html
+++ b/templates/login.html
@@ -13,14 +13,13 @@
     <title>Gophish - {{ .Title }}</title>
 
     <!-- Bootstrap core CSS -->
-    <!-- <link href="/css/bootstrap.css" rel="stylesheet"> -->
     <link href="/bootstrap/css/bootstrap.css" rel="stylesheet">
     <!-- Custom styles for this template -->
     <link href="/css/main.css" rel="stylesheet">
     <link href="/css/dashboard.css" rel="stylesheet">
     <link href="/css/flat-ui.css" rel="stylesheet">
     <link href="/css/font-awesome.min.css" rel="stylesheet">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,600,700' rel='stylesheet' type='text/css'>
 </head>
 
 <body>

--- a/templates/register.html
+++ b/templates/register.html
@@ -13,14 +13,13 @@
     <title>Gophish - {{ .Title }}</title>
 
     <!-- Bootstrap core CSS -->
-    <!-- <link href="/css/bootstrap.css" rel="stylesheet"> -->
     <link href="/bootstrap/css/bootstrap.css" rel="stylesheet">
     <!-- Custom styles for this template -->
     <link href="/css/main.css" rel="stylesheet">
     <link href="/css/dashboard.css" rel="stylesheet">
     <link href="/css/flat-ui.css" rel="stylesheet">
     <link href="/css/font-awesome.min.css" rel="stylesheet">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,600,700' rel='stylesheet' type='text/css'>
 </head>
 
 <body>


### PR DESCRIPTION
This change makes the logo text for the login and register templates use the same font as other templates. If this was intended feel free to close this PR. It also removes a commented out CSS link from the templates.
