### PR TITLE
Clear input after adding group to campaign

### DIFF
--- a/static/js/app/campaigns.js
+++ b/static/js/app/campaigns.js
@@ -303,6 +303,7 @@ $(document).ready(function() {
                     .remove()
                     .draw();
             })
+            $("#groupSelect").val("");
             return false;
         })
         // Create the group typeahead objects


### PR DESCRIPTION
This is a small change to clear the group input when adding groups to a campaign, making it easier to add multiple groups.
