### PR TITLE
Fix group removal

### DIFF
--- a/static/js/app/campaigns.js
+++ b/static/js/app/campaigns.js
@@ -302,24 +302,24 @@ $(document).ready(function() {
             errorFlash("Error fetching campaigns")
         })
     $("#groupForm").submit(function() {
-            // Add row to group table.
-            var newRow = groupTable.row.add([
-                $("#groupSelect").val(),
-                '<span style="cursor:pointer;"><i class="fa fa-trash-o"></i></span>'
-            ]).draw().node();
+        // Add row to group table.
+        var newRow = groupTable.row.add([
+            $("#groupSelect").val(),
+            '<span style="cursor:pointer;"><i class="fa fa-trash-o"></i></span>'
+        ]).draw().node();
 
-            // Set event handler for removing row from group table.
-            $(newRow).on("click", "span>i.fa-trash-o", function() {
-                groupTable.row($(this).parents('tr'))
-                    .remove()
-                    .draw();
-            });
-
-            // Clear user input.
-            $("#groupSelect").val("");
-            return false;
+        // Set event handler for removing row from group table.
+        $(newRow).on("click", "span>i.fa-trash-o", function() {
+            groupTable.row($(this).parents('tr'))
+                .remove()
+                .draw();
         });
-        // Create the group typeahead objects
+
+        // Clear user input.
+        $("#groupSelect").val("");
+        return false;
+    });
+    // Create the group typeahead objects
     groupTable = $("#groupTable").DataTable({
         columnDefs: [{
             orderable: false,

--- a/static/js/app/campaigns.js
+++ b/static/js/app/campaigns.js
@@ -302,18 +302,23 @@ $(document).ready(function() {
             errorFlash("Error fetching campaigns")
         })
     $("#groupForm").submit(function() {
-            groupTable.row.add([
+            // Add row to group table.
+            var newRow = groupTable.row.add([
                 $("#groupSelect").val(),
                 '<span style="cursor:pointer;"><i class="fa fa-trash-o"></i></span>'
-            ]).draw()
-            $("#groupTable").on("click", "span>i.fa-trash-o", function() {
+            ]).draw().node();
+
+            // Set event handler for removing row from group table.
+            $(newRow).on("click", "span>i.fa-trash-o", function() {
                 groupTable.row($(this).parents('tr'))
                     .remove()
                     .draw();
-            })
+            });
+
+            // Clear user input.
             $("#groupSelect").val("");
             return false;
-        })
+        });
         // Create the group typeahead objects
     groupTable = $("#groupTable").DataTable({
         columnDefs: [{


### PR DESCRIPTION
This fixes #249 by making sure the group removal event handler is only set for a newly added row. Previously when adding a group the event handler would get set for all rows, overwriting the original event handlers for previously added rows.

There is code for copying a campaign [here](https://github.com/gophish/gophish/blob/master/static/js/app/campaigns.js#L205) that still needs to be updated; however, I noticed that it currently isn't working correctly and I don't want to make changes that I can't verify. If these changes look good to you I'll see if I can figure out what's going on with the campaign copy code and update it as well.
