### PR TITLE
Add selected group hint in campaign modal

### DIFF
--- a/static/js/app/campaigns.js
+++ b/static/js/app/campaigns.js
@@ -316,7 +316,7 @@ $(document).ready(function() {
         });
 
         // Clear user input.
-        $("#groupSelect").val("");
+        $("#groupSelect").typeahead('val', "");
         return false;
     });
     // Create the group typeahead objects
@@ -351,7 +351,9 @@ $(document).ready(function() {
             }
         })
         .bind('typeahead:select', function(ev, group) {
-            $("#groupSelect").typeahead('val', group.name)
+            // Add selected group.
+            $("#groupSelect").typeahead('val', group.name);
+            $("#groupForm").submit();
         })
         .bind('typeahead:autocomplete', function(ev, group) {
             $("#groupSelect").typeahead('val', group.name)


### PR DESCRIPTION
This is a suggestion to make adding groups to a new campaign a little easier. It updates the "create campaign" modal to add the selected group hint instead of having to click the _+Add_ button as well. This was mentioned in issue #117, I'm not sure if you had different changes in mind.
