### PR TITLE
Add target update capability to API

### DIFF
--- a/controllers/api.go
+++ b/controllers/api.go
@@ -128,8 +128,8 @@ func API_Campaigns_Id_Results(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// API_Groups returns details about the requested group. If the campaign is not
-// valid, API_Groups returns null.
+// API_Groups returns a list of groups if requested via GET.
+// If requested via POST, API_Groups creates a new group and returns a reference to it.
 func API_Groups(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.Method == "GET":
@@ -165,8 +165,8 @@ func API_Groups(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// API_Groups_Id returns details about the requested campaign. If the group is not
-// valid, API_Groups_Id returns null.
+// API_Groups_Id returns details about the requested group.
+// If the group is not valid, API_Groups_Id returns null.
 func API_Groups_Id(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id, _ := strconv.ParseInt(vars["id"], 0, 64)

--- a/models/group.go
+++ b/models/group.go
@@ -156,12 +156,15 @@ func PutGroup(g *Group) error {
 		for _, t := range ts {
 			if t.Email == nt.Email {
 				tExists = true
+				nt.Id = t.Id
 				break
 			}
 		}
-		// If the target is not in the db, we add it
+		// Add target if not in database, otherwise update target information.
 		if !tExists {
 			insertTargetIntoGroup(nt, g.Id)
+		} else {
+			UpdateTarget(nt)
 		}
 	}
 	err = db.Save(g).Error
@@ -218,6 +221,20 @@ func insertTargetIntoGroup(t Target, gid int64) error {
 		return err
 	}
 	return nil
+}
+
+// UpdateTarget updates the given target information in the database.
+func UpdateTarget(target Target) error {
+	targetInfo := map[string]interface{}{
+		"first_name": target.FirstName,
+		"last_name":  target.LastName,
+		"position":   target.Position,
+	}
+	err := db.Model(&target).Where("id = ?", target.Id).Updates(targetInfo).Error
+	if err != nil {
+		Logger.Printf("Error updating target information for %s\n", target.Email)
+	}
+	return err
 }
 
 // GetTargets performs a many-to-many select to get all the Targets for a Group

--- a/models/group.go
+++ b/models/group.go
@@ -123,14 +123,14 @@ func PutGroup(g *Group) error {
 	if err := g.Validate(); err != nil {
 		return err
 	}
+	// Fetch group's existing targets from database.
 	ts := []Target{}
 	ts, err = GetTargets(g.Id)
 	if err != nil {
 		Logger.Printf("Error getting targets from group ID: %d", g.Id)
 		return err
 	}
-	// Enumerate through, removing any entries that are no longer in the group
-	// For every target in the database
+	// Check existing targets, removing any that are no longer in the group.
 	tExists := false
 	for _, t := range ts {
 		tExists = false
@@ -149,8 +149,7 @@ func PutGroup(g *Group) error {
 			}
 		}
 	}
-	// Insert any entries that are not in the database
-	// For every target in the new group
+	// Add any targets that are not in the database yet.
 	for _, nt := range g.Targets {
 		// Check and see if the target already exists in the db
 		tExists = false
@@ -166,7 +165,6 @@ func PutGroup(g *Group) error {
 		}
 	}
 	err = db.Save(g).Error
-	/*_, err = Conn.Update(g)*/
 	if err != nil {
 		Logger.Println(err)
 		return err

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -63,6 +63,31 @@ func (s *ModelsSuite) TestPostGroupNoTargets(c *check.C) {
 	c.Assert(err, check.Equals, ErrNoTargetsSpecified)
 }
 
+func (s *ModelsSuite) TestPutGroup(c *check.C) {
+	// Add test group.
+	group := Group{Name: "Put Test Group"}
+	group.Targets = []Target{
+		Target{Email: "test1@example.com", FirstName: "First", LastName: "Example"},
+		Target{Email: "test2@example.com", FirstName: "Second", LastName: "Example"},
+	}
+	group.UserId = 1
+	PostGroup(&group)
+
+	// Update one of group's targets.
+	group.Targets[0].FirstName = "New"
+	err := PutGroup(&group)
+	c.Assert(err, check.Equals, nil)
+
+	// Verify updated target information.
+	targets, _ := GetTargets(group.Id)
+	c.Assert(targets[0].Email, check.Equals, "test1@example.com")
+	c.Assert(targets[0].FirstName, check.Equals, "New")
+	c.Assert(targets[0].LastName, check.Equals, "Example")
+	c.Assert(targets[1].Email, check.Equals, "test2@example.com")
+	c.Assert(targets[1].FirstName, check.Equals, "Second")
+	c.Assert(targets[1].LastName, check.Equals, "Example")
+}
+
 func (s *ModelsSuite) TestPostSMTP(c *check.C) {
 	smtp := SMTP{
 		Name:        "Test SMTP",

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -88,6 +88,31 @@ func (s *ModelsSuite) TestPutGroup(c *check.C) {
 	c.Assert(targets[1].LastName, check.Equals, "Example")
 }
 
+func (s *ModelsSuite) TestPutGroupEmptyAttribute(c *check.C) {
+	// Add test group.
+	group := Group{Name: "Put Empty Attribute Test Group"}
+	group.Targets = []Target{
+		Target{Email: "test3@example.com", FirstName: "Third", LastName: "Example"},
+		Target{Email: "test4@example.com", FirstName: "Fourth", LastName: "Example"},
+	}
+	group.UserId = 1
+	PostGroup(&group)
+
+	// Update one of group's targets.
+	group.Targets[0].FirstName = ""
+	err := PutGroup(&group)
+	c.Assert(err, check.Equals, nil)
+
+	// Verify updated empty attribute was saved.
+	targets, _ := GetTargets(group.Id)
+	c.Assert(targets[0].Email, check.Equals, "test3@example.com")
+	c.Assert(targets[0].FirstName, check.Equals, "")
+	c.Assert(targets[0].LastName, check.Equals, "Example")
+	c.Assert(targets[1].Email, check.Equals, "test4@example.com")
+	c.Assert(targets[1].FirstName, check.Equals, "Fourth")
+	c.Assert(targets[1].LastName, check.Equals, "Example")
+}
+
 func (s *ModelsSuite) TestPostSMTP(c *check.C) {
 	smtp := SMTP{
 		Name:        "Test SMTP",


### PR DESCRIPTION
This is an idea for fixing #18.

Currently we check all new targets against existing targets to see if any have been removed. If an existing target is missing from the list of new targets it gets removed from the database. This PR changes _PutGroup_ to update a target's information in the database if it still exists during this check.

Note: the web front end still needs to be updated to allow editing. This just adds the capability to the back end.

Let me know if I missed anything or if there's a different approach you'd prefer.
