### PR TITLE
Clean up between model tests

### DIFF
--- a/models/models_test.go
+++ b/models/models_test.go
@@ -45,6 +45,15 @@ func (s *ModelsSuite) TestGetUser(c *check.C) {
 	c.Assert(u.Username, check.Equals, "admin")
 }
 
+func (s *ModelsSuite) TestPutUser(c *check.C) {
+	u, err := GetUser(1)
+	u.Username = "admin_changed"
+	err = PutUser(&u)
+	c.Assert(err, check.Equals, nil)
+	u, err = GetUser(1)
+	c.Assert(u.Username, check.Equals, "admin_changed")
+}
+
 func (s *ModelsSuite) TestGeneratedAPIKey(c *check.C) {
 	u, err := GetUser(1)
 	c.Assert(err, check.Equals, nil)
@@ -236,13 +245,4 @@ func (s *ModelsSuite) TestPostPage(c *check.C) {
 		_, ok = f.Find("input").Attr("name")
 		c.Assert(ok, check.Equals, false)
 	})
-}
-
-func (s *ModelsSuite) TestPutUser(c *check.C) {
-	u, err := GetUser(1)
-	u.Username = "admin_changed"
-	err = PutUser(&u)
-	c.Assert(err, check.Equals, nil)
-	u, err = GetUser(1)
-	c.Assert(u.Username, check.Equals, "admin_changed")
 }

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/gophish/gophish/config"
+	"github.com/jinzhu/gorm"
 	"gopkg.in/check.v1"
 )
 
@@ -134,9 +135,8 @@ func (s *ModelsSuite) TestGetGroup(c *check.C) {
 }
 
 func (s *ModelsSuite) TestGetGroupNoGroups(c *check.C) {
-	group, err := GetGroup(1, 1)
-	c.Assert(err, check.Not(check.Equals), nil)
-	c.Assert(group.Name, check.Not(check.Equals), "Test Group")
+	_, err := GetGroup(1, 1)
+	c.Assert(err, check.Equals, gorm.ErrRecordNotFound)
 }
 
 func (s *ModelsSuite) TestGetGroupByName(c *check.C) {
@@ -156,9 +156,8 @@ func (s *ModelsSuite) TestGetGroupByName(c *check.C) {
 }
 
 func (s *ModelsSuite) TestGetGroupByNameNoGroups(c *check.C) {
-	group, err := GetGroupByName("Test Group", 1)
-	c.Assert(err, check.Not(check.Equals), nil)
-	c.Assert(group.Name, check.Not(check.Equals), "Test Group")
+	_, err := GetGroupByName("Test Group", 1)
+	c.Assert(err, check.Equals, gorm.ErrRecordNotFound)
 }
 
 func (s *ModelsSuite) TestPutGroup(c *check.C) {

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -86,6 +86,63 @@ func (s *ModelsSuite) TestPostGroupNoTargets(c *check.C) {
 	c.Assert(err, check.Equals, ErrNoTargetsSpecified)
 }
 
+func (s *ModelsSuite) TestGetGroups(c *check.C) {
+	// Add groups.
+	PostGroup(&Group{
+		Name:    "Test Group 1",
+		Targets: []Target{Target{Email: "test1@example.com"}},
+		UserId:  1,
+	})
+	PostGroup(&Group{
+		Name:    "Test Group 2",
+		Targets: []Target{Target{Email: "test2@example.com"}},
+		UserId:  1,
+	})
+
+	// Get groups and test result.
+	groups, err := GetGroups(1)
+	c.Assert(err, check.Equals, nil)
+	c.Assert(len(groups), check.Equals, 2)
+	c.Assert(len(groups[0].Targets), check.Equals, 1)
+	c.Assert(len(groups[1].Targets), check.Equals, 1)
+	c.Assert(groups[0].Name, check.Equals, "Test Group 1")
+	c.Assert(groups[1].Name, check.Equals, "Test Group 2")
+	c.Assert(groups[0].Targets[0].Email, check.Equals, "test1@example.com")
+	c.Assert(groups[1].Targets[0].Email, check.Equals, "test2@example.com")
+}
+
+func (s *ModelsSuite) TestGetGroup(c *check.C) {
+	// Add group.
+	PostGroup(&Group{
+		Name:    "Test Group",
+		Targets: []Target{Target{Email: "test@example.com"}},
+		UserId:  1,
+	})
+
+	// Get group and test result.
+	group, err := GetGroup(1, 1)
+	c.Assert(err, check.Equals, nil)
+	c.Assert(len(group.Targets), check.Equals, 1)
+	c.Assert(group.Name, check.Equals, "Test Group")
+	c.Assert(group.Targets[0].Email, check.Equals, "test@example.com")
+}
+
+func (s *ModelsSuite) TestGetGroupByName(c *check.C) {
+	// Add group.
+	PostGroup(&Group{
+		Name:    "Test Group",
+		Targets: []Target{Target{Email: "test@example.com"}},
+		UserId:  1,
+	})
+
+	// Get group and test result.
+	group, err := GetGroupByName("Test Group", 1)
+	c.Assert(err, check.Equals, nil)
+	c.Assert(len(group.Targets), check.Equals, 1)
+	c.Assert(group.Name, check.Equals, "Test Group")
+	c.Assert(group.Targets[0].Email, check.Equals, "test@example.com")
+}
+
 func (s *ModelsSuite) TestPutGroup(c *check.C) {
 	// Add test group.
 	group := Group{Name: "Test Group"}

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -111,6 +111,12 @@ func (s *ModelsSuite) TestGetGroups(c *check.C) {
 	c.Assert(groups[1].Targets[0].Email, check.Equals, "test2@example.com")
 }
 
+func (s *ModelsSuite) TestGetGroupsNoGroups(c *check.C) {
+	groups, err := GetGroups(1)
+	c.Assert(err, check.Equals, nil)
+	c.Assert(len(groups), check.Equals, 0)
+}
+
 func (s *ModelsSuite) TestGetGroup(c *check.C) {
 	// Add group.
 	PostGroup(&Group{
@@ -127,6 +133,12 @@ func (s *ModelsSuite) TestGetGroup(c *check.C) {
 	c.Assert(group.Targets[0].Email, check.Equals, "test@example.com")
 }
 
+func (s *ModelsSuite) TestGetGroupNoGroups(c *check.C) {
+	group, err := GetGroup(1, 1)
+	c.Assert(err, check.Not(check.Equals), nil)
+	c.Assert(group.Name, check.Not(check.Equals), "Test Group")
+}
+
 func (s *ModelsSuite) TestGetGroupByName(c *check.C) {
 	// Add group.
 	PostGroup(&Group{
@@ -141,6 +153,12 @@ func (s *ModelsSuite) TestGetGroupByName(c *check.C) {
 	c.Assert(len(group.Targets), check.Equals, 1)
 	c.Assert(group.Name, check.Equals, "Test Group")
 	c.Assert(group.Targets[0].Email, check.Equals, "test@example.com")
+}
+
+func (s *ModelsSuite) TestGetGroupByNameNoGroups(c *check.C) {
+	group, err := GetGroupByName("Test Group", 1)
+	c.Assert(err, check.Not(check.Equals), nil)
+	c.Assert(group.Name, check.Not(check.Equals), "Test Group")
 }
 
 func (s *ModelsSuite) TestPutGroup(c *check.C) {

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -25,6 +25,20 @@ func (s *ModelsSuite) SetUpSuite(c *check.C) {
 	}
 }
 
+func (s *ModelsSuite) TearDownTest(c *check.C) {
+	// Clear database tables between each test. If new tables are
+	// used in this test suite they will need to be cleaned up here.
+	db.Delete(Group{})
+	db.Delete(Target{})
+	db.Delete(GroupTarget{})
+	db.Delete(SMTP{})
+	db.Delete(Page{})
+
+	// Reset users table to default state.
+	db.Not("id", 1).Delete(User{})
+	db.Model(User{}).Update("username", "admin")
+}
+
 func (s *ModelsSuite) TestGetUser(c *check.C) {
 	u, err := GetUser(1)
 	c.Assert(err, check.Equals, nil)

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -88,7 +88,7 @@ func (s *ModelsSuite) TestPostGroupNoTargets(c *check.C) {
 
 func (s *ModelsSuite) TestPutGroup(c *check.C) {
 	// Add test group.
-	group := Group{Name: "Put Test Group"}
+	group := Group{Name: "Test Group"}
 	group.Targets = []Target{
 		Target{Email: "test1@example.com", FirstName: "First", LastName: "Example"},
 		Target{Email: "test2@example.com", FirstName: "Second", LastName: "Example"},
@@ -97,14 +97,14 @@ func (s *ModelsSuite) TestPutGroup(c *check.C) {
 	PostGroup(&group)
 
 	// Update one of group's targets.
-	group.Targets[0].FirstName = "New"
+	group.Targets[0].FirstName = "Updated"
 	err := PutGroup(&group)
 	c.Assert(err, check.Equals, nil)
 
 	// Verify updated target information.
 	targets, _ := GetTargets(group.Id)
 	c.Assert(targets[0].Email, check.Equals, "test1@example.com")
-	c.Assert(targets[0].FirstName, check.Equals, "New")
+	c.Assert(targets[0].FirstName, check.Equals, "Updated")
 	c.Assert(targets[0].LastName, check.Equals, "Example")
 	c.Assert(targets[1].Email, check.Equals, "test2@example.com")
 	c.Assert(targets[1].FirstName, check.Equals, "Second")
@@ -113,10 +113,10 @@ func (s *ModelsSuite) TestPutGroup(c *check.C) {
 
 func (s *ModelsSuite) TestPutGroupEmptyAttribute(c *check.C) {
 	// Add test group.
-	group := Group{Name: "Put Empty Attribute Test Group"}
+	group := Group{Name: "Test Group"}
 	group.Targets = []Target{
-		Target{Email: "test3@example.com", FirstName: "Third", LastName: "Example"},
-		Target{Email: "test4@example.com", FirstName: "Fourth", LastName: "Example"},
+		Target{Email: "test1@example.com", FirstName: "First", LastName: "Example"},
+		Target{Email: "test2@example.com", FirstName: "Second", LastName: "Example"},
 	}
 	group.UserId = 1
 	PostGroup(&group)
@@ -128,11 +128,11 @@ func (s *ModelsSuite) TestPutGroupEmptyAttribute(c *check.C) {
 
 	// Verify updated empty attribute was saved.
 	targets, _ := GetTargets(group.Id)
-	c.Assert(targets[0].Email, check.Equals, "test3@example.com")
+	c.Assert(targets[0].Email, check.Equals, "test1@example.com")
 	c.Assert(targets[0].FirstName, check.Equals, "")
 	c.Assert(targets[0].LastName, check.Equals, "Example")
-	c.Assert(targets[1].Email, check.Equals, "test4@example.com")
-	c.Assert(targets[1].FirstName, check.Equals, "Fourth")
+	c.Assert(targets[1].Email, check.Equals, "test2@example.com")
+	c.Assert(targets[1].FirstName, check.Equals, "Second")
 	c.Assert(targets[1].LastName, check.Equals, "Example")
 }
 


### PR DESCRIPTION
This is an idea for cleaning up between tests. _gocheck_ offers `TearDownTest` and `TearDownSuite` for cleaning up either at the end of each test or at the end of the entire test suite. I implemented this for the model tests and cleaned up the existing tests a bit.

Some downsides:
- This needs to be set up and managed for each test suite. This PR only does so for _ModelsSuite_. One solution would be to create a separate clean up function that each `TearDownTest` function calls, but I wasn't sure where the best place to put that would be.
- This PR attempts to reset the _users_ table after each test but it doesn't handle the case of a test deleting the default user. I looked into clearing the table and adding the default user back, but the method for resetting the primary key seed was SQLite dependent. I'm sure there's an easy way that I'm not aware of.
