### PR TITLE
Resource leak

### DIFF
--- a/controllers/api.go
+++ b/controllers/api.go
@@ -551,7 +551,7 @@ func API_Import_Site(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Insert the base href tag to better handle relative resources
-	d, err := goquery.NewDocumentFromReader(resp.Body)
+	d, err := goquery.NewDocumentFromResponse(resp)
 	if err != nil {
 		JSONResponse(w, models.Response{Success: false, Message: err.Error()}, http.StatusBadRequest)
 		return


### PR DESCRIPTION
Hi,
I just saw that the response object created in line 548 was never closed..  https://github.com/gophish/gophish/blob/master/controllers/api.go#L548

On the other hand,in line 554 
https://github.com/gophish/gophish/blob/master/controllers/api.go#L554
Instead of using goquery.NewDocumentFromReader, if goquery.NewDocumentFromResponse is used, goquery reads from the response object and closes it after its done.

This is the code snippet for goquery.NewDocumentFromReader
https://github.com/PuerkitoBio/goquery/blob/master/type.go#L48

and code snippet for goquery.NewDocumentFromResponse
https://github.com/PuerkitoBio/goquery/blob/master/type.go#L59

and response is being close through line 63 of  goquery.NewDocumentFromResponse
https://github.com/PuerkitoBio/goquery/blob/master/type.go#L63
