### PR TITLE
Sending Campaign Emails in Parallel

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,7 +14,8 @@
 	"smtp" : {
 		"host" : "smtp.example.com:25",
 		"user" : "username",
-		"pass" : "password"
+		"pass" : "password",
+		"pool_size" : 5
 	},
 	"db_path" : "gophish.db",
 	"migrations_path" : "db/migrations/"

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ type SMTPServer struct {
 	Host     string `json:"host"`
 	User     string `json:"user"`
 	Password string `json:"password"`
+	PoolSize int    `json:"pool_size"`
 }
 
 // AdminServer represents the Admin server configuration details

--- a/worker/mailer.go
+++ b/worker/mailer.go
@@ -1,0 +1,63 @@
+package worker
+
+import (
+	"gopkg.in/gomail.v2"
+	"time"
+)
+
+type email struct {
+	message   *gomail.Message
+	onError   func(err error)
+	onSuccess func()
+}
+
+func createPool(d *gomail.Dialer, size int, buffer int) chan *email {
+	ch := make(chan *email, buffer)
+
+	for i := 0; i < size; i++ {
+		go func() {
+			var s gomail.SendCloser
+			var err error
+			open := false
+			for {
+				select {
+				case m, ok := <-ch:
+					if !ok {
+						if open {
+							if err := s.Close(); err != nil {
+								Logger.Println(" Unable to close SMTP connection ", err)
+							}
+						}
+						return
+					}
+					if !open {
+						if s, err = d.Dial(); err != nil {
+							go m.onError(err)
+						} else {
+							open = true
+						}
+					}
+					if open {
+						if err := gomail.Send(s, m.message); err != nil {
+							go m.onError(err)
+						} else {
+							go m.onSuccess()
+						}
+					}
+				// Close the connection to the SMTP server if no email was sent in
+				// the last 30 seconds.
+				case <-time.After(30 * time.Second):
+					if open {
+						if err := s.Close(); err != nil {
+							Logger.Println(" Unable to close SMTP connection ", err)
+						}
+						open = false
+					}
+
+				}
+			}
+		}()
+	}
+
+	return ch
+}


### PR DESCRIPTION
The current implementation sends emails synchronously.

For every campaign email, 
1. the email content is first created
2. SMTP connection is opened 
3. the mail is sent.
4. then steps 1-3 are repeated again for the next campaign email after 1-3 are completed for the previous email

In this pull request,
Step 1 is put in Go-Routines. (A go-routine is started for each and every email which prepares the content of the mails concurrently)
Step 2 is modified to create a pool of SMTP connections (where every connection is a go-routine waiting on a buffered channel shared between them) where the number of connections can be set through config.json 
And Step 3 is accomplished when go-routines in Step 1 push the prepared object into the buffered channel for consumption by the SMTP pool.

This source code snippet from https://gopkg.in/gomail.v2 was referenced for this pull request
https://godoc.org/gopkg.in/gomail.v2#example-package--Daemon
