### PR TITLE
Generate self-signed certificates for administration interface

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,9 +1,9 @@
 {
 	"admin_server" : {
 		"listen_url" : "127.0.0.1:3333",
-		"use_tls" : false,
-		"cert_path" : "example.crt",
-		"key_path" : "example.key"
+		"use_tls" : true,
+		"cert_path" : "adminserver.crt",
+		"key_path" : "adminserver.key"
 	},
 	"phish_server" : {
 		"listen_url" : "0.0.0.0:80",

--- a/gophish.go
+++ b/gophish.go
@@ -26,11 +26,20 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
 	"fmt"
 	"log"
+	"math/big"
 	"net/http"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/gophish/gophish/auth"
@@ -57,6 +66,10 @@ func main() {
 		auth.Store.Options.Secure = config.Conf.AdminConf.UseTLS
 		if config.Conf.AdminConf.UseTLS { // use TLS for Admin web server if available
 			Logger.Printf("Starting admin server at https://%s\n", config.Conf.AdminConf.ListenURL)
+			err := CheckAndCreateSSL(config.Conf.AdminConf.ListenURL, config.Conf.AdminConf.CertPath, config.Conf.AdminConf.KeyPath, Logger)
+			if err != nil {
+				Logger.Fatal(err)
+			}
 			Logger.Fatal(http.ListenAndServeTLS(config.Conf.AdminConf.ListenURL, config.Conf.AdminConf.CertPath, config.Conf.AdminConf.KeyPath,
 				handlers.CombinedLoggingHandler(os.Stdout, adminHandler)))
 		} else {
@@ -78,4 +91,71 @@ func main() {
 		}
 	}()
 	wg.Wait()
+}
+
+func CheckAndCreateSSL(ListenURL string, CertPath string, KeyPath string, Logger *log.Logger) error {
+	// Check whether there is an existing SSL certificate and/or key, and if so, abort execution of this function
+	if _, err := os.Stat(CertPath); !os.IsNotExist(err) {
+		return nil
+	}
+	if _, err := os.Stat(KeyPath); !os.IsNotExist(err) {
+		return nil
+	}
+
+	Logger.Printf("Creating new self-signed certificates for administration interface...\n")
+
+	// RSA would be a perfectly fine alternative
+	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+
+	notBefore := time.Now()
+	// Generate a certificate that lasts for 10 years
+	notAfter := notBefore.Add(10 * 365 * 24 * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+
+	if err != nil {
+		return errors.New(fmt.Sprintf("TLS Certificate Generation: Failed to generate a random serial number: %s", err))
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.Public(), priv)
+	if err != nil {
+		return errors.New(fmt.Sprintf("TLS Certificate Generation: Failed to create certificate: %s", err))
+	}
+
+	certOut, err := os.Create(CertPath)
+	if err != nil {
+		return errors.New(fmt.Sprintf("TLS Certificate Generation: Failed to open %s for writing: %s", CertPath, err))
+	}
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	certOut.Close()
+
+	keyOut, err := os.OpenFile(KeyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return errors.New(fmt.Sprintf("TLS Certificate Generation: Failed to open %s for writing", KeyPath))
+	}
+
+	b, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return errors.New(fmt.Sprintf("TLS Certificate Generation: Unable to marshal ECDSA private key: %v", err))
+	}
+
+	pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: b})
+	keyOut.Close()
+
+	Logger.Println("TLS Certificate Generation complete")
+	return nil
 }


### PR DESCRIPTION
The documentation mentioned that at some point this might be automated, so I wrote an implementation.

I assume this is better placed in a controller, but I wasn't sure where was best (especially since it's not likely to be used anywhere else in the code), so I have just written it here for now.

ECDSA could easily be changed to RSA if requested.

I have refrained from writing similar code for the phishing interface as it is most likely going to not be productive to have a non-valid certificate on that interface.
