### PR TITLE
Support for sending emails with custom headers

### DIFF
--- a/db/migrations/20161013000001_custom_email_headers.sql
+++ b/db/migrations/20161013000001_custom_email_headers.sql
@@ -1,0 +1,12 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+CREATE TABLE IF NOT EXISTS custom_headers(
+	id integer primary key autoincrement,
+	key varchar(255),
+	value varchar(255),
+	"template_id" bigint
+);
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+DROP TABLE custom_headers;

--- a/models/campaign.go
+++ b/models/campaign.go
@@ -145,6 +145,11 @@ func (c *Campaign) getDetails() error {
 		Logger.Println(err)
 		return err
 	}
+	err = db.Where("template_id=?", c.Template.Id).Find(&c.Template.CustomHeaders).Error
+	if err != nil && err != gorm.ErrRecordNotFound {
+		Logger.Println(err)
+		return err
+	}
 	err = db.Table("pages").Where("id=?", c.PageId).Find(&c.Page).Error
 	if err != nil {
 		if err != gorm.ErrRecordNotFound {

--- a/models/custom_header.go
+++ b/models/custom_header.go
@@ -1,0 +1,10 @@
+package models
+
+// CustomHeader contains the fields and methods for
+// an email templates to have custom headers
+type CustomHeader struct {
+	Id         int64  `json:"-"`
+	TemplateId int64  `json:"-"`
+	Key        string `json:"key"`
+	Value      string `json:"value"`
+}

--- a/templates/templates.html
+++ b/templates/templates.html
@@ -117,6 +117,30 @@
                 <tbody>
                 </tbody>
             </table>
+	    <hr>
+	    <label class="control-label" for="custom_headers">Custom Email Headers:</label>
+	    <form id="customHeadersForm">
+	    	<div class="col-md-4">
+			<input type="text" class="form-control" name="custom_header" id="customHeaderKey" placeholder="x-custom-header">
+		</div>
+		<div class="col-md-4">
+			<input type="text" class="form-control" name="custom_value" id="customHeaderValue" placeholder="{{"{{"}}.URL{{"}}"}}-gophish">
+		</div>
+		<div class="col-md-2">
+	    		<button class="btn btn-danger btn-headers" type="submit"><i class="fa fa-plus"></i> Add Custom Header</button>
+		</div>
+	    </form>
+	  <br />
+	  <br />
+          <table id="customHeadersTable" class="table table-hover table-striped table-condensed">
+              <thead>
+                  <tr>
+                      <th>Header</th>
+                      <th>Value</th>
+		      <th class="no-sort"></th>
+              <tbody>
+              </tbody>
+          </table>
         </div>
         <div class="modal-footer">
             <button type="button" data-dismiss="modal" class="btn btn-default" onclick="dismiss()">Cancel</button>

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -127,7 +127,36 @@ func processCampaign(c *models.Campaign) {
 			"<img style='display: none' src='" + c.URL + "/track?rid=" + t.RId + "'/>",
 			fn,
 		}
-		// Parse the templates
+
+		// Parse the customHeader templates
+		for _, customHeader := range c.Template.CustomHeaders {
+			parsedHeader := struct {
+				Key   bytes.Buffer
+				Value bytes.Buffer
+			}{}
+			keytmpl, err := template.New("text_template").Parse(customHeader.Key)
+			if err != nil {
+				Logger.Println(err)
+			}
+			err = keytmpl.Execute(&parsedHeader.Key, td)
+			if err != nil {
+				Logger.Println(err)
+			}
+
+			valtmpl, err := template.New("text_template").Parse(customHeader.Value)
+			if err != nil {
+				Logger.Println(err)
+			}
+			err = valtmpl.Execute(&parsedHeader.Value, td)
+			if err != nil {
+				Logger.Println(err)
+			}
+
+			// Add our header immediately
+			e.SetHeader(parsedHeader.Key.String(), parsedHeader.Value.String())
+		}
+
+		// Parse remaining templates
 		var subjBuff bytes.Buffer
 		tmpl, err := template.New("text_template").Parse(c.Template.Subject)
 		if err != nil {


### PR DESCRIPTION
Adds an option during email template creation to specify any additional and/or custom email headers to be appended to the sent email.
These are parsed using the templating system to allow for variables to be used.

Closes #128

Example UI:
![image](https://cloud.githubusercontent.com/assets/191510/19314324/396b20a8-90f6-11e6-9f7e-8c1ca44b0668.png)

I'm not happy with the UI yet, so if anyone has improvements, just suggest them and I'll be happy to implement.
