### PR TITLE
Users&Groups Selective Processing

### DIFF
--- a/controllers/api.go
+++ b/controllers/api.go
@@ -580,6 +580,10 @@ func API_Import_Site(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
+func API_Datatable_Dummy(w http.ResponseWriter, r *http.Request) {
+	JSONResponse(w, models.Response{Success: true, Message: "Empty Json"}, http.StatusOK)
+}
+
 // API_Send_Test_Email sends a test email using the template name
 // and Target given.
 func API_Send_Test_Email(w http.ResponseWriter, r *http.Request) {

--- a/controllers/route.go
+++ b/controllers/route.go
@@ -63,6 +63,7 @@ func CreateAdminRouter() http.Handler {
 	api.HandleFunc("/import/group", API_Import_Group)
 	api.HandleFunc("/import/email", API_Import_Email)
 	api.HandleFunc("/import/site", API_Import_Site)
+	api.HandleFunc("/datatables/dummy", API_Datatable_Dummy)
 
 	// Setup static file serving
 	router.PathPrefix("/").Handler(http.FileServer(http.Dir("./static/")))

--- a/static/js/app/users.js
+++ b/static/js/app/users.js
@@ -3,6 +3,7 @@ var PostData = []
 var targetsTable ;
 var tableInfo = {};
 tableInfo.start=0;
+tableInfo.order=0;
 tableInfo.length=0;
 
 // Save attempts to POST or PUT to /groups/
@@ -82,15 +83,45 @@ function edit(idx) {
           data:function(params){
               tableInfo.start = params.start;
               tableInfo.length = params.length;
+              tableInfo.order = params.order;
               delete params.draw;
               delete params.columns;
-              delete params.order;
+            //   delete params.order;
               delete params.search;
               delete params.length;
               delete params.start;
               return;
           },
           dataSrc:function(json){
+              PostData = PostData.sort(
+                  function(a,b){
+                      if(tableInfo.order[0].column==0){
+                        if(tableInfo.order[0].dir=="asc"){
+                            return a.first_name>b.first_name?1:0;
+                        } else {
+                            return a.first_name<b.first_name?1:0;
+                        }
+                      } else if(tableInfo.order[0].column==1){
+                          if(tableInfo.order[0].dir=="asc"){
+                              return a.last_name>b.last_name?1:0;
+                          } else {
+                              return a.last_name<b.last_name?1:0;
+                          }
+                      } else if(tableInfo.order[0].column==2){
+                          if(tableInfo.order[0].dir=="asc"){
+                              return a.email>b.email?1:0;
+                          } else {
+                              return a.email<b.email?1:0;
+                          }
+                      } else if(tableInfo.order[0].column==3){
+                          if(tableInfo.order[0].dir=="asc"){
+                              return a.position>b.position?1:0;
+                          } else {
+                              return a.position<b.position?1:0;
+                          }
+                      }
+                  }
+              );
               var data = [];
               for(var i=tableInfo.start;i<tableInfo.start+tableInfo.length && i<PostData.length;i++){
                   data.push(xssParsing(PostData[i]));
@@ -101,17 +132,17 @@ function edit(idx) {
               return json.data;
           }
       },
-        infoCallback:   function( settings, start, end, max, total, pre ) {
-                            var info = "";
-                            if(PostData.length<=tableInfo.length){
-                                info += "Showing "+(PostData.length)+" to "+PostData.length;
-                            } else{
-                                info += "Showing "+(tableInfo.start+1)+" to "+(tableInfo.start+1+tableInfo.length);
-                            }
-                            info += " of "+PostData.length+" entries"
-                            return info;
-                        },
-        ordering: false,
+        // infoCallback:   function( settings, start, end, max, total, pre ) {
+        //                     var info = "";
+        //                     if(PostData.length<=tableInfo.length){
+        //                         info += "Showing "+(PostData.length)+" to "+PostData.length;
+        //                     } else{
+        //                         info += "Showing "+(tableInfo.start+1)+" to "+(tableInfo.start+1+tableInfo.length);
+        //                     }
+        //                     info += " of "+PostData.length+" entries"
+        //                     return info;
+        //                 },
+        // ordering: false,
         deferRender:    true,
         destroy: true, // Destroy any other instantiated table - http://datatables.net/manual/tech-notes/3#destroy
         columnDefs: [{

--- a/static/js/app/users.js
+++ b/static/js/app/users.js
@@ -95,7 +95,10 @@ function edit(idx) {
               for(var i=tableInfo.start;i<tableInfo.start+tableInfo.length && i<PostData.length;i++){
                   data.push(xssParsing(PostData[i]));
               }
-              return data;
+              json.recordsFiltered = PostData.length;
+              json.recordsTotal = PostData.length;
+              json.data = data;
+              return json.data;
           }
       },
         infoCallback:   function( settings, start, end, max, total, pre ) {


### PR DESCRIPTION
In Users&Groups, when a huge CSV file is being uploaded (lets say it has 50,000 records ),
then according to the following line https://github.com/gophish/gophish/blob/master/static/js/app/users.js#L97 , addTarget function is being called for each of those entries.

And This line in addTarget function https://github.com/gophish/gophish/blob/master/static/js/app/users.js#L143 , draws the table again and again, after adding each entry into the table.

This slows down the performance considerably. The browser hangs and we get alerts popping up asking for confirmation to kill the script.

In DataTables, there is an option called "server side processing"
https://datatables.net/examples/data_sources/server_side.html 

In this kind of processing, the datatable always stores only one page in the FrontEnd. Anytime a new page is requested, The server is polled. And the dataTable is updated with new results.

^^ In our case, the data is available only in the FrontEnd.
So, I have created a dummy API called /api/datatables/dummy, which when polled, always returns an empty Json.
And in the FrontEnd, I enabled server side processing on the datatable, and pointed the url to the dummy API. Upon receiving back this meaningless json in the FrontEnd, the ajax.dataSrc function is triggered. 
https://datatables.net/reference/option/ajax.dataSrc
In which, I add the local json i have stored in the global variable called PostData, to the server's Json
https://github.com/svigne1/gophish/blob/groups_ui/static/js/app/users.js#L100

This way, Selective processing of Huge DataSets, is accomplished on the frontend.

Additional functions like 
https://datatables.net/reference/option/infoCallback (to render the description of the table)

and removeDuplicates() which sorts PostData whenever its updated, and removes the duplicate items have been used
https://github.com/svigne1/gophish/blob/groups_ui/static/js/app/users.js#L53

Awaiting your feedback

