### PR TITLE
Bug Fix - In generationRid Function

### DIFF
--- a/models/result.go
+++ b/models/result.go
@@ -74,7 +74,7 @@ func (r *Result) GenerateId() {
 	for {
 		io.ReadFull(rand.Reader, k)
 		r.RId = fmt.Sprintf("%x", k)
-		err := db.Table("results").Where("id=?", r.RId).First(&Result{}).Error
+		err := db.Table("results").Where("r_id=?", r.RId).First(&Result{}).Error
 		if err == gorm.ErrRecordNotFound {
 			break
 		}


### PR DESCRIPTION
Hi,
In this line, 
https://github.com/gophish/gophish/blob/master/models/result.go#L77
the query is wrongly checking id with rid ! 
err := db.Table("results").Where("id=?", r.RId).First(&Result{}).Error

So, even if, there is already an Rid existing in database, the duplicate rid, is considered to be unique and inserted into table. So, the purpose is not served. ( https://github.com/gophish/gophish/blob/master/models/result.go#L72 )

I have correct the query to the following.
err := db.Table("results").Where("r_id=?", r.RId).First(&Result{}).Error

Please merge my request.