### PR TITLE
Gzip Best Compression

### DIFF
--- a/gophish.go
+++ b/gophish.go
@@ -26,6 +26,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 import (
+	"compress/gzip"
 	"fmt"
 	"log"
 	"net/http"
@@ -54,7 +55,8 @@ func main() {
 	// Start the web servers
 	go func() {
 		defer wg.Done()
-		adminHandler := gziphandler.GzipHandler(controllers.CreateAdminRouter())
+		gzipWrapper, _ := gziphandler.NewGzipLevelHandler(gzip.BestCompression)
+		adminHandler := gzipWrapper(controllers.CreateAdminRouter())
 		auth.Store.Options.Secure = config.Conf.AdminConf.UseTLS
 		if config.Conf.AdminConf.UseTLS { // use TLS for Admin web server if available
 			err := util.CheckAndCreateSSL(config.Conf.AdminConf.CertPath, config.Conf.AdminConf.KeyPath)


### PR DESCRIPTION
Hi,
The current code in `Gophish.go` uses [GzipHandler](https://github.com/gophish/gophish/blob/master/gophish.go#L57) which passes [DefaultCompression](https://github.com/NYTimes/gziphandler/blob/master/gzip.go#L178) to `NewGzipLevelHandler` by default.

I have copy pasted the two lines inside `GzipHandler` and i am passing `BestCompression` instead of `DefaultCompression`.

This increases performance considerably. I tried inserting a csv with 5 lakh entries in it. It took 1.1 minutes to get back the Json response form the server.
But now with this change, it takes only 5.94 seconds.

Hope this helps.