### PR TITLE
Groups Page - Putting Limit on Targets selected

### DIFF
--- a/models/group.go
+++ b/models/group.go
@@ -63,7 +63,7 @@ func GetGroups(uid int64) ([]Group, error) {
 		return gs, err
 	}
 	for i, _ := range gs {
-		gs[i].Targets, err = GetTargets(gs[i].Id)
+		gs[i].Targets, err = GetLimitedTargets(gs[i].Id)
 		if err != nil {
 			Logger.Println(err)
 		}
@@ -241,5 +241,12 @@ func UpdateTarget(target Target) error {
 func GetTargets(gid int64) ([]Target, error) {
 	ts := []Target{}
 	err := db.Table("targets").Select("targets.id, targets.email, targets.first_name, targets.last_name, targets.position").Joins("left join group_targets gt ON targets.id = gt.target_id").Where("gt.group_id=?", gid).Scan(&ts).Error
+	return ts, err
+}
+
+// GetTargets performs a many-to-many select to get all the Targets for a Group
+func GetLimitedTargets(gid int64) ([]Target, error) {
+	ts := []Target{}
+	err := db.Limit(10).Table("targets").Select("targets.id, targets.email, targets.first_name, targets.last_name, targets.position").Joins("left join group_targets gt ON targets.id = gt.target_id").Where("gt.group_id=?", gid).Scan(&ts).Error
 	return ts, err
 }

--- a/static/js/app/users.js
+++ b/static/js/app/users.js
@@ -67,17 +67,24 @@ function edit(idx) {
         group = {}
     } else {
         group = groups[idx]
-        $("#name").val(group.name)
-        $.each(group.targets, function(i, record) {
-            targets.DataTable()
-                .row.add([
-                    escapeHtml(record.first_name),
-                    escapeHtml(record.last_name),
-                    escapeHtml(record.email),
-                    escapeHtml(record.position),
-                    '<span style="cursor:pointer;"><i class="fa fa-trash-o"></i></span>'
-                ]).draw()
-        });
+        api.groupId.get(group.id)
+          .success(function(gs) {
+              group = gs;
+              $("#name").val(group.name)
+              $.each(group.targets, function(i, record) {
+                  targets.DataTable()
+                      .row.add([
+                          escapeHtml(record.first_name),
+                          escapeHtml(record.last_name),
+                          escapeHtml(record.email),
+                          escapeHtml(record.position),
+                          '<span style="cursor:pointer;"><i class="fa fa-trash-o"></i></span>'
+                      ]).draw()
+              });
+          })
+          .error(function() {
+              errorFlash("Error fetching groups")
+          })
     }
     // Handle file uploads
     $("#csvupload").fileupload({


### PR DESCRIPTION
Hi,
When we go to the groups page in the admin server. The [`load`](https://github.com/gophish/gophish/blob/master/static/js/app/users.js#L153) function in `users.js` makes a call to `API_Groups` which [fetches](https://github.com/gophish/gophish/blob/master/controllers/api.go#L152) all the groups from DB along with all the [targets](https://github.com/gophish/gophish/blob/master/models/group.go#L241) of each group

As a result, the Groups Page takes a long time to load waiting for group targets it doesn't need.Since only 4-5 Targets for each group is [displayed](https://github.com/gophish/gophish/blob/master/static/js/app/users.js#L173) in the Groups Page. Rest all are omitted by adding "...".

So, I have included a GetLimitedTargets function which fetches only 15 targets for each group.
And in the [`edit`](https://github.com/gophish/gophish/blob/master/static/js/app/users.js#L69) function, I am making a call to `api.groupId.get` to get all the targets of a group for display.

