### PR TITLE
Scale Campaigns & Dashboard Page

### DIFF
--- a/controllers/api.go
+++ b/controllers/api.go
@@ -64,11 +64,17 @@ func API_Reset(w http.ResponseWriter, r *http.Request) {
 func API_Campaigns(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.Method == "GET":
-		cs, err := models.GetCampaigns(ctx.Get(r, "user_id").(int64))
+		cs, s, err := models.GetCampaigns(ctx.Get(r, "user_id").(int64))
 		if err != nil {
 			Logger.Println(err)
 		}
-		JSONResponse(w, cs, http.StatusOK)
+		JSONResponse(w, struct {
+			Campaigns []models.Campaign `json:"campaigns"`
+			Avg       []int64           `json:"avg"`
+		}{
+			Campaigns: cs,
+			Avg:       s,
+		}, http.StatusOK)
 	//POST: Create a new campaign and return it as JSON
 	case r.Method == "POST":
 		c := models.Campaign{}

--- a/static/js/app/campaigns.js
+++ b/static/js/app/campaigns.js
@@ -298,7 +298,7 @@ $(document).ready(function() {
     });
     api.campaigns.get()
         .success(function(cs) {
-            campaigns = cs
+            campaigns = cs["campaigns"]
             $("#loading").hide()
             if (campaigns.length > 0) {
                 $("#campaignTable").show()

--- a/static/js/app/dashboard.js
+++ b/static/js/app/dashboard.js
@@ -23,7 +23,7 @@ $(document).ready(function() {
     api.campaigns.get()
         .success(function(cs) {
             $("#loading").hide()
-            campaigns = cs
+            campaigns = cs["campaigns"];
             if (campaigns.length > 0) {
                 $("#dashboard").show()
                     // Create the overview chart data
@@ -72,15 +72,10 @@ $(document).ready(function() {
                     </button></div>"
                         ]).draw()
                         // Add it to the chart data
-                    campaign.y = 0
-                    $.each(campaign.results, function(j, result) {
-                        if (result.status == "Success") {
-                            campaign.y++;
-                        }
-                    })
-                    campaign.y = Math.floor((campaign.y / campaign.results.length) * 100)
-                    average += campaign.y
-                        // Add the data to the overview chart
+                    campaign.y = cs["avg"][i];
+                    console.log(campaign.y);
+                    average += campaign.y;
+                    // Add the data to the overview chart
                     overview_data.labels.push(campaign_date)
                     overview_data.series[0].push({
                         meta: i,


### PR DESCRIPTION
Hi,
Like #460 , The dashboard page and campaign pages are very slow to load since [`getDetails`](https://github.com/gophish/gophish/blob/master/models/campaign.go#L124) function called by `API_Campaigns` collects all the information related to a campaign like `results`,`events`,`smtp`,`page` etc. 

But the dashboard page and the campaigns page don't require this information. The Campaigns page  requires only the name and status. And the Dashboard page requires success percentage in addition to  names and status.

i have written a `avgSuccess` function which calculates the average using sql.
Thereby reducing the load on JS to calculate the avg and increasing performance
Hope this helps
