### PR TITLE
Attachment Bug Fix

### DIFF
--- a/db/db_mysql/migrations/20161202153627_AttachmentFix.sql
+++ b/db/db_mysql/migrations/20161202153627_AttachmentFix.sql
@@ -1,0 +1,9 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE attachments MODIFY content LONGTEXT;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+ALTER TABLE attachments MODIFY content TEXT;


### PR DESCRIPTION
Hi,
When the config is changed to point to a Mysql Db. Then I am facing problems when i try to send attachments of size > 49 KB.
So, if an image with size > 49 KB is saved in the email template and say a campaign is launched.
The Mail server throws "UNEXPECTED EOF" error. And in the mail you receive, you only get a cropped image.

Changing text to longtext fixes the problem for me. 