### PR TITLE
User defined delay between emails

### DIFF
--- a/controllers/api.go
+++ b/controllers/api.go
@@ -75,11 +75,13 @@ func API_Campaigns(w http.ResponseWriter, r *http.Request) {
 		// Put the request into a campaign
 		err := json.NewDecoder(r.Body).Decode(&c)
 		if err != nil {
+			Logger.Println(err)
 			JSONResponse(w, models.Response{Success: false, Message: "Invalid JSON structure"}, http.StatusBadRequest)
 			return
 		}
 		err = models.PostCampaign(&c, ctx.Get(r, "user_id").(int64))
 		if err != nil {
+			Logger.Println("bob12345")
 			JSONResponse(w, models.Response{Success: false, Message: err.Error()}, http.StatusBadRequest)
 			return
 		}

--- a/controllers/api.go
+++ b/controllers/api.go
@@ -81,7 +81,6 @@ func API_Campaigns(w http.ResponseWriter, r *http.Request) {
 		}
 		err = models.PostCampaign(&c, ctx.Get(r, "user_id").(int64))
 		if err != nil {
-			Logger.Println("bob12345")
 			JSONResponse(w, models.Response{Success: false, Message: err.Error()}, http.StatusBadRequest)
 			return
 		}

--- a/db/db_sqlite3/dbconf.yml
+++ b/db/db_sqlite3/dbconf.yml
@@ -1,5 +1,5 @@
 production:
-    driver: sqlite3 
+    driver: sqlite3
     open: gophish.db
     dialect: sqlite3
     import: github.com/mattn/go-sqlite3

--- a/db/db_sqlite3/migrations/20161206114715_0.2_fix_launch_and_add_smtp_delay.sql
+++ b/db/db_sqlite3/migrations/20161206114715_0.2_fix_launch_and_add_smtp_delay.sql
@@ -1,0 +1,9 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE "campaigns" ADD COLUMN "delay" integer;
+
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+

--- a/models/campaign.go
+++ b/models/campaign.go
@@ -26,6 +26,7 @@ type Campaign struct {
 	SMTPId        int64     `json:"-"`
 	SMTP          SMTP      `json:"smtp"`
 	URL           string    `json:"url"`
+	Delay         int64    `json:"delay,string"`
 }
 
 // CampaignResults is a struct representing the results from a campaign
@@ -91,6 +92,7 @@ type SendTestEmailRequest struct {
 	Tracker     string   `json:"tracker"`
 	TrackingURL string   `json:"tracking_url"`
 	From        string   `json:"from"`
+	Delay       int64    `json:"delay,string"`
 	Target
 }
 

--- a/static/js/app/campaigns.js
+++ b/static/js/app/campaigns.js
@@ -44,6 +44,7 @@ function launch() {
                         smtp: {
                             name: $("#profile").val()
                         },
+			delay: $("#delay").val(),
                         launch_date: moment($("#launch_date").val(), "MM/DD/YYYY hh:mm a").format(),
                         groups: groups
                     }
@@ -113,6 +114,7 @@ function dismiss() {
     $("#page").val("")
     $("#url").val("")
     $("#profile").val("")
+    $("#delay").val("")
     $("#groupSelect").val("")
     $("#modal").modal('hide')
     $("#groupTable").dataTable().DataTable().clear().draw()
@@ -245,6 +247,7 @@ function copy(idx) {
     $("#template").val(campaign.template.name)
     $("#page").val(campaign.page.name)
     $("#profile").val(campaign.smtp.name)
+    $("#delay").val(campaign.delay)
     $("#url").val(campaign.url)
 }
 

--- a/templates/campaigns.html
+++ b/templates/campaigns.html
@@ -76,6 +76,10 @@
               <label class="control-label" for="template">Email Template:</label>
               <input type="text" class="typeahead form-control" placeholder="Template Name" id="template"/>
               <br>
+                <label class="control-label" for="delay">Sending Delay: <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="Delay between emails sent in seconds (must be an integer!)"></i></label>
+              <input name="number" onkeyup="if (/\D/g.test(this.value)) this.value = this.value.replace(/\D/g,'')" class="form-control" value=0 id="delay"/>
+	      <!--input type="number" onkeyup="if (/\D/g.test(this.value)) this.value = this.value.replace(/\D/g,'')" class="form-control" id="delay"/-->
+		<br>
 	      <label class="control-label" for="page">Landing Page:</label>
 	      <input type="text" class="typeahead form-control" placeholder="Landing Page" id="page"/>
 	      <br>
@@ -90,9 +94,9 @@
 		    <button type="button" data-toggle="modal" data-target="#sendTestEmailModal" class="btn btn-primary typeahead-button"><i class="fa fa-envelope"></i> Send Test Email</button>
 		</span>
 	      </div>
-              <label class="control-label" for="users">Groups:</label>
+		 <label class="control-label" for="users">Groups:</label>
               <form id="groupForm">
-                  <div class="input-group">
+                 <div class="input-group">
                       <input type="text" class="typeahead form-control" placeholder="Group Name" id="groupSelect" />
                       <span class="input-group-btn">
                           <button class="btn btn-primary typeahead-button"><i class="fa fa-plus"></i> Add</button>

--- a/templates/campaigns.html
+++ b/templates/campaigns.html
@@ -76,10 +76,9 @@
               <label class="control-label" for="template">Email Template:</label>
               <input type="text" class="typeahead form-control" placeholder="Template Name" id="template"/>
               <br>
-                <label class="control-label" for="delay">Sending Delay: <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="Delay between emails sent in seconds (must be an integer!)"></i></label>
+              <label class="control-label" for="delay">Sending Delay: <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="Delay between emails sent in seconds (must be an integer!)"></i></label>
               <input name="number" onkeyup="if (/\D/g.test(this.value)) this.value = this.value.replace(/\D/g,'')" class="form-control" value=0 id="delay"/>
-	      <!--input type="number" onkeyup="if (/\D/g.test(this.value)) this.value = this.value.replace(/\D/g,'')" class="form-control" id="delay"/-->
-		<br>
+	      <br>
 	      <label class="control-label" for="page">Landing Page:</label>
 	      <input type="text" class="typeahead form-control" placeholder="Landing Page" id="page"/>
 	      <br>
@@ -94,9 +93,9 @@
 		    <button type="button" data-toggle="modal" data-target="#sendTestEmailModal" class="btn btn-primary typeahead-button"><i class="fa fa-envelope"></i> Send Test Email</button>
 		</span>
 	      </div>
-		 <label class="control-label" for="users">Groups:</label>
+		<label class="control-label" for="users">Groups:</label>
               <form id="groupForm">
-                 <div class="input-group">
+                <div class="input-group">
                       <input type="text" class="typeahead form-control" placeholder="Group Name" id="groupSelect" />
                       <span class="input-group-btn">
                           <button class="btn btn-primary typeahead-button"><i class="fa fa-plus"></i> Add</button>

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -110,6 +110,8 @@ func processCampaign(c *models.Campaign) {
 		}
 		return
 	}
+	//grab delay for the campaign
+	delay := c.Delay
 	// Send each email
 	e := gomail.NewMessage()
 	for _, t := range c.Results {
@@ -209,6 +211,10 @@ func processCampaign(c *models.Campaign) {
 				Logger.Println(err)
 			}
 		}
+                //Pause for user defined amount of time (in seconds) between emails
+                duration := time.Duration(delay)*time.Second
+                Logger.Println("Pausing for ",delay," seconds...")
+                time.Sleep(duration)
 		e.Reset()
 	}
 	err = c.UpdateStatus(models.CAMPAIGN_EMAILS_SENT)


### PR DESCRIPTION
So I had seen a few people saying that they would like a delay for sending emails as some systems might block a large amount of email coming in one go or some people might want to run a campaign slowly over a large time period.

With that in mind, I've done a few simple changes and added the ability to define a delay between emails per campaign. There is a field added into the new campaign screen which defines the delay, in seconds. This field is set to 0 by default, and should only allow numbers (so no decimals, letters or negative numbers allowed). Feedback more than welcome...


Also, I added an error output to api.go (this was something I'd added in to trace a JSON error I was having, so I don't think it necessarily needs to stay. I have also deleted a space in db/db_sqlite3/dbconf.yml as it was causing issues when using goose up/down. 

I haven't done this for mysql, as I am using sqlite and wouldn't have a means to test it, that said it should be about as trivial as replicating the column in mysql to allow for the change.