### PR TITLE
Deleting campaign & groups fast

### DIFF
--- a/models/campaign.go
+++ b/models/campaign.go
@@ -331,22 +331,22 @@ func PostCampaign(c *Campaign, uid int64) error {
 //DeleteCampaign deletes the specified campaign
 func DeleteCampaign(id int64) error {
 	Logger.Printf("Deleting campaign %d\n", id)
-	// Delete all the campaign results
-	err := db.Where("campaign_id=?", id).Delete(&Result{}).Error
-	if err != nil {
-		Logger.Println(err)
-		return err
-	}
-	err = db.Where("campaign_id=?", id).Delete(&Event{}).Error
-	if err != nil {
-		Logger.Println(err)
-		return err
-	}
 	// Delete the campaign
 	err = db.Delete(&Campaign{Id: id}).Error
 	if err != nil {
 		Logger.Println(err)
 	}
+	go func() {
+		// Delete all the campaign results
+		err := db.Where("campaign_id=?", id).Delete(&Result{}).Error
+		if err != nil {
+			Logger.Println(err)
+		}
+		err = db.Where("campaign_id=?", id).Delete(&Event{}).Error
+		if err != nil {
+			Logger.Println(err)
+		}
+	}()
 	return err
 }
 

--- a/models/group.go
+++ b/models/group.go
@@ -177,18 +177,20 @@ func PutGroup(g *Group) error {
 
 // DeleteGroup deletes a given group by group ID and user ID
 func DeleteGroup(g *Group) error {
-	// Delete all the group_targets entries for this group
-	err := db.Where("group_id=?", g.Id).Delete(&GroupTarget{}).Error
-	if err != nil {
-		Logger.Println(err)
-		return err
-	}
 	// Delete the group itself
 	err = db.Delete(g).Error
 	if err != nil {
 		Logger.Println(err)
 		return err
 	}
+	go func() {
+		// Delete all the group_targets entries for this group
+		err := db.Where("group_id=?", g.Id).Delete(&GroupTarget{}).Error
+		if err != nil {
+			Logger.Println(err)
+		}
+	}()
+
 	return err
 }
 


### PR DESCRIPTION
Hi,
For campaigns, I am moving the deletion of events and results into a go-routine.
For Groups, I am moving the deletion of groupTargets into a go-routine.

And i am ignoring the errors thrown in the go-routine.

The reasoning is, I think, even if the db operation in the go-routine alone fails for some reason, the details related to that group or campaign being deleted still remains in the database. But there is no way, (either through the api or through the browser), for the end-user to retrieve that data from the database. So, its as good as calling it deleted.

Even in file systems, when we delete a file. Only the inode is deleted and the file contents remain as it is  in the file system. Even though the contents are note deleted and still remain in the file system.There is no way for the end-user to access those contents without the inode entry.

The only problem is, In the case of file systems the new files overwrite the deleted files.
But in database, they stay there forever.

I think, a chance at data inefficiency is acceptable for the boost in performance we get.
Please correct me if i am wrong