### PR TITLE
Added refresh button and reduced lag for large campaigns

### DIFF
--- a/templates/campaign_results.html
+++ b/templates/campaign_results.html
@@ -54,6 +54,9 @@
             <button type="button" class="btn btn-danger" data-toggle="tooltip" onclick="deleteCampaign()">
                 <i class="fa fa-trash-o fa-lg"></i> Delete
             </button>
+            <button id="refresh_btn" type="button" class="btn btn-blue" data-toggle="tooltip" onclick="refresh()">
+                <i class="fa fa-refresh fa-lg"></i> Refresh
+            </button>
 	    <span id="refresh_message">
 		    <i class="fa fa-spin fa-spinner"></i> Refreshing
             </span>


### PR DESCRIPTION
This is a really simple one, I've increased the automatic refresh time to 60 seconds and implemented a refresh button to manually kick off a refresh if desired. I also moved the refresh_message.hide() code to the end of the poll() function, so that it will show 'refreshing' until it is actually finished refreshing