### PR TITLE
Added Education Template for Creating Educational Redirect Pages Insi...

### DIFF
--- a/gophish.go
+++ b/gophish.go
@@ -2,21 +2,16 @@ package main
 
 /*
 gophish - Open-Source Phishing Framework
-
 The MIT License (MIT)
-
 Copyright (c) 2013 Jordan Wright
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,12 +28,10 @@ import (
 	"os"
 	"sync"
 
-	"gopkg.in/alecthomas/kingpin.v2"
-
+	"./controllers"
 	"github.com/NYTimes/gziphandler"
 	"github.com/gophish/gophish/auth"
 	"github.com/gophish/gophish/config"
-	"github.com/gophish/gophish/controllers"
 	"github.com/gophish/gophish/models"
 	"github.com/gophish/gophish/util"
 	"github.com/gorilla/handlers"
@@ -46,14 +39,9 @@ import (
 
 var (
 	Logger = log.New(os.Stdout, " ", log.Ldate|log.Ltime|log.Lshortfile)
-
-	configPath = kingpin.Flag("config", "Location of config.json.").Default("./config.json").String()
 )
 
 func main() {
-	// Parse the CLI flags and load the config
-	kingpin.Parse()
-	config.LoadConfig(*configPath)
 	// Setup the global variables and settings
 	err := models.Setup()
 	if err != nil {

--- a/templates/base.html
+++ b/templates/base.html
@@ -53,6 +53,8 @@
                     </li>
                     <li><a href="/landing_pages">Landing Pages</a>
                     </li>
+                    <li><a href="/education">Education</a>
+                    </li>
                     <li><a href="/sending_profiles">Sending Profiles</a>
                     </li>
                     <li><a href="/settings">Settings</a>

--- a/templates/campaign_results.html
+++ b/templates/campaign_results.html
@@ -13,6 +13,8 @@
                 </li>
                 <li><a href="/landing_pages">Landing Pages</a>
                 </li>
+                 <li><a href="/education">Education</a>
+                </li>
                 <li><a href="/sending_profiles">Sending Profiles</a>
                 </li>
                 <li><a href="/settings">Settings</a>

--- a/templates/campaigns.html
+++ b/templates/campaigns.html
@@ -13,6 +13,8 @@
                 </li>
                 <li><a href="/landing_pages">Landing Pages</a>
                 </li>
+                 <li><a href="/education">Education</a>
+                </li>
                 <li><a href="/sending_profiles">Sending Profiles</a>
                 </li>
                 <li><a href="/settings">Settings</a>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -13,6 +13,8 @@
                 </li>
                 <li><a href="/landing_pages">Landing Pages</a>
                 </li>
+                <li><a href="/education">Education</a>
+                </li>
                 <li><a href="/sending_profiles">Sending Profiles</a>
                 </li>
                 <li><a href="/settings">Settings</a>
@@ -45,9 +47,15 @@
             </div>
             <div class="col-lg-6 col-md-6 col-sm-12 col-xs-12">
                 <p style="text-align:center;">Average Phishing Results</p>
-                <div id="stats_chart" class="col-lg-7 col-md-7"></div>
-                <div class="col-lg-5 col-md-5">
-                    <ul id="stats_chart_legend" class="chartist-legend">
+                <div id="average_chart" class="col-lg-7 col-md-7"></div>
+                <div id="average_chart_legend" class="col-lg-5 col-md-5">
+                    <ul class="chartist-legend">
+                        <li>
+                            <span style="background-color:#f05b4f;"></span> Successful Phishes
+                        </li>
+                        <li>
+                            <span style="background-color:#1abc9c;"></span> Unsuccessful Phishes
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/templates/education.html
+++ b/templates/education.html
@@ -1,0 +1,205 @@
+{{define "body"}}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-sm-3 col-md-2 sidebar">
+            <ul class="nav nav-sidebar">
+                <li><a href="/">Dashboard</a>
+                </li>
+                <li><a href="/campaigns">Campaigns</a>
+                </li>
+                <li><a href="/users">Users &amp; Groups</a>
+                </li>
+                <li><a href="/templates">Email Templates</a>
+                </li>
+                <li><a href="/landing_pages">Landing Pages</a>
+                </li>
+                 <li><a href="/education">Education</a>
+                </li>
+                <li><a href="/sending_profiles">Sending Profiles</a>
+                </li>
+                <li><a href="/settings">Settings</a>
+                </li>
+                <li><hr></li>
+                <li><a href="https://gophish.gitbooks.io/user-guide/content/">User Guide</a>
+                </li>
+                <li><a href="/api/">API Documentation</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>
+<div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
+    <h1 class="page-header">
+        Education
+    </h1>
+    <div id="flashes" class="row"></div>
+    <div class="row">
+        <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#modal"><i class="fa fa-plus"></i> New Page</button>
+    </div>
+    &nbsp;
+<div id="emptyMessage" class="row" {{if not .Message}} style="display:none;"{{end}}>
+        <div class="alert alert-info">
+            {{if .Message}} {{.Message}} {{end}}
+        </div>
+    </div>
+
+{{if .List}} 
+
+<div class="row">
+        <table id="pagesTable" class="table">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Last Modified Date</th>
+                    <th class="col-md-2 no-sort"></th>
+                </tr>
+            </thead>
+
+{{range $index,$article := .List }}
+
+            <tbody id="t_{{$index}}">
+
+                <tr role="row">
+                    <td id="edu_name_{{$index}}"class="sorting_1">{{- .Name -}}</td>
+                    <td>{{- .Body -}}</td>
+                    <td class="col-md-2 no-sort"></td>
+                    <td>
+
+                        <div class="pull-right">
+
+                            <span data-toggle="modal" data-target="#modal"><button class="btn btn-primary" data-toggle="tooltip" data-placement="left" title="" onclick="edit({{$index}})" data-original-title="Edit Page">                    <i class="fa fa-pencil"></i>                    </button></span>                      
+                            
+                            <button class="btn btn-danger" data-toggle="tooltip" data-placement="left" title="" onclick="deletePage({{$index}})" data-original-title="Delete Page"><i class="fa fa-trash-o"></i>                    </button>
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
+        
+{{end}}
+
+</table>
+    </div>
+<div class="dataTables_info" id="pagesTable_info" role="status" aria-live="polite">Showing {{len .List}} of {{len .List}} entries</div>
+
+{{end}}
+   
+</div>
+<!-- Modal -->
+<div class="modal fade" id="modal" tabindex="-1" role="dialog" aria-labelledby="modalLabel">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+        <!-- New Template Modal -->
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close" onclick="dismiss()"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title" id="modalLabel">New Landing Page</h4>
+        </div>
+        <div class="modal-body">
+            <div class="row" id="modal.flashes"></div>
+            <label class="control-label" for="name">Name:</label>
+            <div class="form-group">
+                <input type="text" class="form-control" placeholder="Page name" id="name" autofocus/>
+            </div>
+            <!-- Nav tabs -->
+            <ul class="nav nav-tabs" role="tablist">
+                <li class="active" role="html"><a href="#html" aria-controls="html" role="tab" data-toggle="tab">HTML</a></li>
+            </ul>
+            <!-- Tab panes -->
+            <div class="tab-content">
+                <div role="tabpanel" class="tab-pane active" id="html">
+                    <textarea id="html_editor"></textarea>
+                </div>
+            </div>
+        <div class="modal-footer">
+            <button type="button" data-dismiss="modal" class="btn btn-default" onclick="dismiss()">Cancel</button>
+            <button type="button" data-dismiss="modal" class="btn btn-primary" id="modalSubmit" onclick="submar()">Save Page</button>
+        </div>
+        <input type="hidden" name="csrf_token" value="{{.Token}}"/>
+    </div>
+  </div>
+</div>
+<!-- Modal -->
+
+{{end}}
+{{define "scripts"}}
+<script src="/js/src/vendor/ckeditor/ckeditor.js"></script>
+<script src="/js/src/vendor/ckeditor/adapters/jquery.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+
+<script>
+
+    CKEDITOR.replace( 'html_editor' );
+
+    var token = document.getElementsByName("csrf_token")[0].value;
+
+    function submar() {
+        var name = document.getElementById("name").value;
+        var body = CKEDITOR.instances.html_editor.getData();
+        var formData = {"action": "SUBMIT", "name": name, "body":body, "csrf_token": token};
+        $.ajax({
+            type        : 'POST', 
+            url         : 'education', 
+            data        : formData, 
+            dataType    : 'json', 
+                        encode          : true
+        })
+            .done(function(data) {
+                document.getElementById('emptyMessage').style.display = "block";
+                document.getElementsByClassName('alert alert-info')[0].innerHTML = data;
+            });
+        event.preventDefault();
+        dismiss();
+      }  
+    
+function dismiss() {
+    $("#name").val("")
+    CKEDITOR.instances.html_editor.setData('');
+    $("#modal").modal('hide')
+}
+
+function edit(id) {
+        var iden = "edu_name_".concat(id);
+        var name = document.getElementById(iden).innerHTML;
+        var formData = {"action": "EDIT", "name": name, "csrf_token": token};
+        $.ajax({
+            type        : 'POST', 
+            url         : 'education', 
+            data        : formData, 
+            dataType    : 'json', 
+                        encode          : true
+        })
+            .done(function(data) {
+                document.getElementById("name").value = name;
+                CKEDITOR.instances.html_editor.setData(data);
+            });
+        event.preventDefault();
+      }  
+
+function deletePage(id) {
+        var iden = "edu_name_".concat(id);
+        var name = document.getElementById(iden).innerHTML;
+        var formData = {"action": "DELETE", "name": name, "csrf_token": token};
+        $.ajax({
+            type        : 'POST', 
+            url         : 'education', 
+            data        : formData, 
+            dataType    : 'json', 
+                        encode          : true
+        })
+            .done(function(data) {
+                document.getElementById('emptyMessage').style.display = "block";
+                document.getElementsByClassName('alert alert-info')[0].innerHTML = data;
+                var tbod = "t_".concat(id);
+                var table = document.getElementById(tbod);
+                table.parentNode.removeChild(table);
+            });
+
+        event.preventDefault();
+
+      }  
+
+</script>
+
+{{end}}
+
+
+

--- a/templates/landing_pages.html
+++ b/templates/landing_pages.html
@@ -13,6 +13,8 @@
                 </li>
                 <li class="active"><a href="/landing_pages">Landing Pages</a>
                 </li>
+                 <li><a href="/education">Education</a>
+                </li>
                 <li><a href="/sending_profiles">Sending Profiles</a>
                 </li>
                 <li><a href="/settings">Settings</a>
@@ -97,9 +99,33 @@
 		</div>
             </div>
             <div id="redirect_url">
-                <label class="control-label" for="redirect_url_input">Redirect to: <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="This option lets you redirect the user to a page after credentials are submitted."></i></label>
+                <label class="control-label" for="redirect_url_input">Redirect to: <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="Redirect the user to a page after submitting credentials.  Redirect to Education pages with the following URL: http://phishing_server/static/ + [name] +.html"></i></label>
                 <div class="form-group">
-                    <input id="redirect_url_input" class="form-control" placeholder="http://example.com"/>
+
+                
+
+                    <input id="redirect_url_input" class="form-control" list="browsers" name="browser">
+
+
+                        {{if .List}} 
+
+
+                        <datalist id="browsers">
+
+
+                            {{range $article := .List }}
+
+
+                            <option value="http://phishing_server/static/{{$article}}">
+                            
+                            {{end}}
+
+                        </datalist>    
+
+                        {{end}}     
+
+
+
                 </div>
             </div>
         </div>

--- a/templates/sending_profiles.html
+++ b/templates/sending_profiles.html
@@ -13,6 +13,8 @@
                 </li>
                 <li><a href="/landing_pages">Landing Pages</a>
                 </li>
+                 <li><a href="/education">Education</a>
+                </li>
                 <li class="active"><a href="/sending_profiles">Sending Profiles</a>
                 </li>
                 <li><a href="/settings">Settings</a>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -13,6 +13,8 @@
                 </li>
                 <li><a href="/landing_pages">Landing Pages</a>
                 </li>
+                 <li><a href="/education">Education</a>
+                </li>
                 <li><a href="/sending_profiles">Sending Profiles</a>
                 </li>
                 <li class="active"><a href="/settings">Settings</a>

--- a/templates/templates.html
+++ b/templates/templates.html
@@ -13,6 +13,8 @@
                 </li>
                 <li><a href="/landing_pages">Landing Pages</a>
                 </li>
+                 <li><a href="/education">Education</a>
+                </li>
                 <li><a href="/sending_profiles">Sending Profiles</a>
                 </li>
                 <li><a href="/settings">Settings</a>

--- a/templates/users.html
+++ b/templates/users.html
@@ -13,6 +13,8 @@
                 </li>
                 <li><a href="/landing_pages">Landing Pages</a>
                 </li>
+                 <li><a href="/education">Education</a>
+                </li>
                 <li><a href="/sending_profiles">Sending Profiles</a>
                 </li>
                 <li><a href="/settings">Settings</a>


### PR DESCRIPTION
…de Static Folder

Redirecting phishing victims to pages hosted on the phishing server is a very useful feature, currently implemented in GoPhish through the /static folder.  One example where this is particularly useful, for instance, is for phishing campaigns in which victims should be redirected to an educational page, alerting them that they had fallen for a phishing attack and explaining how to avoid attacks in the future.  This fork demonstrates an additional feature added to the admin page, which allows HTML files inside the /static directory to be created, modified and deleted.  On the landing_pages URL, these pages are also suggested in a drop down menu on the redirect_URL field.  The changes are very simple, only 2 .go files were modified so the fork can easily be compiled and tested on Desktop, everything is done through AJAX like the Settings page (no new models created or API functions modified).  

Perhaps if this seems desirable, you can consider implementing this feature in the future.  Thank you for your work on GoPhish, the framework is fantastic!

---------------------------------------------------------------------------------------------

gophish.go: /controllers is imported from relevant local directory, for purposes of compiling changes made therein

controllers/route.go: Added handling for /education URL, including handling AJAX requests

templates/education.html: New template for creating, editing and managing HTML pages inside the static folder.  

templates/landing_pages.html: Added some information to the hover help icon by the redirect field, and a dropdown that suggests files from the static folder.

/templates: Most of the other templates had the education page href added to their menus