### PR TITLE
hidden overflow on targetsTable

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -437,8 +437,14 @@ p {
 
 /* Table Styling */
 
+.modal-content table {
+    table-layout: fixed;
+}
+
 .modal-content .dataTable tbody td {
     font-size: 16px;
+    overflow: hidden;
+    text-overflow: ellipsis;
     /* Smaller font on modal tables */
 }
 


### PR DESCRIPTION
## Related Issue
https://github.com/gophish/gophish/issues/904

## Overview
Texts overflow on targetsTable, so I hidden overflow by adding some styles.

**before**

![2018-01-07 14 08 19](https://user-images.githubusercontent.com/7028383/34646762-44f94414-f3b4-11e7-8a33-722ffce8b281.png)

**after**

![2018-01-07 14 09 53](https://user-images.githubusercontent.com/7028383/34646770-78f1b24c-f3b4-11e7-80ee-61096c0a4555.png)


