### PR TITLE
Add gophish_admin.crt and gophish_admin.key to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ _cgo_export.*
 
 _testmain.go
 
+gophish_admin.crt
+gophish_admin.key
+
 *.exe
 *.db


### PR DESCRIPTION
Those files should not be committed at any chance so I think that would be safer if those files are added to .gitignore
  