### PR TITLE
Increase the size for Landing Pages and Templates in MySQL.

### DIFF
--- a/db/db_mysql/migrations/20160118194630_init.sql
+++ b/db/db_mysql/migrations/20160118194630_init.sql
@@ -2,11 +2,11 @@
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
 CREATE TABLE IF NOT EXISTS users (id integer primary key auto_increment,username varchar(255) NOT NULL UNIQUE,hash varchar(255),api_key varchar(255) NOT NULL UNIQUE );
-CREATE TABLE IF NOT EXISTS templates (id integer primary key auto_increment,user_id bigint,name varchar(255),subject varchar(255),text text,html text,modified_date datetime );
+CREATE TABLE IF NOT EXISTS templates (id integer primary key auto_increment,user_id bigint,name varchar(255),subject varchar(255),text text,html longtext,modified_date datetime );
 CREATE TABLE IF NOT EXISTS targets (id integer primary key auto_increment,first_name varchar(255),last_name varchar(255),email varchar(255),position varchar(255) );
 CREATE TABLE IF NOT EXISTS smtp (smtp_id integer primary key auto_increment,campaign_id bigint,host varchar(255),username varchar(255),from_address varchar(255) );
 CREATE TABLE IF NOT EXISTS results (id integer primary key auto_increment,campaign_id bigint,user_id bigint,r_id varchar(255),email varchar(255),first_name varchar(255),last_name varchar(255),status varchar(255) NOT NULL ,ip varchar(255),latitude real,longitude real );
-CREATE TABLE IF NOT EXISTS pages (id integer primary key auto_increment,user_id bigint,name varchar(255),html text,modified_date datetime );
+CREATE TABLE IF NOT EXISTS pages (id integer primary key auto_increment,user_id bigint,name varchar(255),html longtext,modified_date datetime );
 CREATE TABLE IF NOT EXISTS groups (id integer primary key auto_increment,user_id bigint,name varchar(255),modified_date datetime );
 CREATE TABLE IF NOT EXISTS group_targets (group_id bigint,target_id bigint );
 CREATE TABLE IF NOT EXISTS events (id integer primary key auto_increment,campaign_id bigint,email varchar(255),time datetime,message varchar(255) );


### PR DESCRIPTION
Currently if you are using MySQL the columns for Landing Page and Template contents are limited in size by their type - TEXT. This means that if you try uploading a page larger than 65535 characters it will get silently cut off.

It is easy to fix this in the console by modifying the type:

`alter table pages modify html longtext;`

However it would of course be best to have this done automatically. These are the two places that I've found this to be configurable.