### PR TITLE
Added quoting around table names for MySQL migrations

### DIFF
--- a/db/db_mysql/migrations/20160118194630_init.sql
+++ b/db/db_mysql/migrations/20160118194630_init.sql
@@ -1,28 +1,28 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-CREATE TABLE IF NOT EXISTS users (id integer primary key auto_increment,username varchar(255) NOT NULL UNIQUE,hash varchar(255),api_key varchar(255) NOT NULL UNIQUE );
-CREATE TABLE IF NOT EXISTS templates (id integer primary key auto_increment,user_id bigint,name varchar(255),subject varchar(255),text text,html text,modified_date datetime );
-CREATE TABLE IF NOT EXISTS targets (id integer primary key auto_increment,first_name varchar(255),last_name varchar(255),email varchar(255),position varchar(255) );
-CREATE TABLE IF NOT EXISTS smtp (smtp_id integer primary key auto_increment,campaign_id bigint,host varchar(255),username varchar(255),from_address varchar(255) );
-CREATE TABLE IF NOT EXISTS results (id integer primary key auto_increment,campaign_id bigint,user_id bigint,r_id varchar(255),email varchar(255),first_name varchar(255),last_name varchar(255),status varchar(255) NOT NULL ,ip varchar(255),latitude real,longitude real );
-CREATE TABLE IF NOT EXISTS pages (id integer primary key auto_increment,user_id bigint,name varchar(255),html text,modified_date datetime );
-CREATE TABLE IF NOT EXISTS groups (id integer primary key auto_increment,user_id bigint,name varchar(255),modified_date datetime );
-CREATE TABLE IF NOT EXISTS group_targets (group_id bigint,target_id bigint );
-CREATE TABLE IF NOT EXISTS events (id integer primary key auto_increment,campaign_id bigint,email varchar(255),time datetime,message varchar(255) );
-CREATE TABLE IF NOT EXISTS campaigns (id integer primary key auto_increment,user_id bigint,name varchar(255) NOT NULL ,created_date datetime,completed_date datetime,template_id bigint,page_id bigint,status varchar(255),url varchar(255) );
-CREATE TABLE IF NOT EXISTS attachments (id integer primary key auto_increment,template_id bigint,content text,type varchar(255),name varchar(255) );
+CREATE TABLE IF NOT EXISTS `users` (id integer primary key auto_increment,username varchar(255) NOT NULL UNIQUE,hash varchar(255),api_key varchar(255) NOT NULL UNIQUE );
+CREATE TABLE IF NOT EXISTS `templates` (id integer primary key auto_increment,user_id bigint,name varchar(255),subject varchar(255),text text,html text,modified_date datetime );
+CREATE TABLE IF NOT EXISTS `targets` (id integer primary key auto_increment,first_name varchar(255),last_name varchar(255),email varchar(255),position varchar(255) );
+CREATE TABLE IF NOT EXISTS `smtp` (smtp_id integer primary key auto_increment,campaign_id bigint,host varchar(255),username varchar(255),from_address varchar(255) );
+CREATE TABLE IF NOT EXISTS `results` (id integer primary key auto_increment,campaign_id bigint,user_id bigint,r_id varchar(255),email varchar(255),first_name varchar(255),last_name varchar(255),status varchar(255) NOT NULL ,ip varchar(255),latitude real,longitude real );
+CREATE TABLE IF NOT EXISTS `pages` (id integer primary key auto_increment,user_id bigint,name varchar(255),html text,modified_date datetime );
+CREATE TABLE IF NOT EXISTS `groups` (id integer primary key auto_increment,user_id bigint,name varchar(255),modified_date datetime );
+CREATE TABLE IF NOT EXISTS `group_targets` (group_id bigint,target_id bigint );
+CREATE TABLE IF NOT EXISTS `events` (id integer primary key auto_increment,campaign_id bigint,email varchar(255),time datetime,message varchar(255) );
+CREATE TABLE IF NOT EXISTS `campaigns` (id integer primary key auto_increment,user_id bigint,name varchar(255) NOT NULL ,created_date datetime,completed_date datetime,template_id bigint,page_id bigint,status varchar(255),url varchar(255) );
+CREATE TABLE IF NOT EXISTS `attachments` (id integer primary key auto_increment,template_id bigint,content text,type varchar(255),name varchar(255) );
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
-DROP TABLE attachments;
-DROP TABLE campaigns;
-DROP TABLE events;
-DROP TABLE group_targets;
-DROP TABLE groups;
-DROP TABLE pages;
-DROP TABLE results;
-DROP TABLE smtp;
-DROP TABLE targets;
-DROP TABLE templates;
-DROP TABLE users;
+DROP TABLE `attachments`;
+DROP TABLE `campaigns`;
+DROP TABLE `events`;
+DROP TABLE `group_targets`;
+DROP TABLE `groups`;
+DROP TABLE `pages`;
+DROP TABLE `results`;
+DROP TABLE `smtp`;
+DROP TABLE `targets`;
+DROP TABLE `templates`;
+DROP TABLE `users`;

--- a/db/db_mysql/migrations/20160131153104_0.1.2_add_event_details.sql
+++ b/db/db_mysql/migrations/20160131153104_0.1.2_add_event_details.sql
@@ -1,7 +1,7 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE events ADD COLUMN details BLOB;
+ALTER TABLE `events` ADD COLUMN details BLOB;
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back

--- a/db/db_mysql/migrations/20160211211220_0.1.2_add_ignore_cert_errors.sql
+++ b/db/db_mysql/migrations/20160211211220_0.1.2_add_ignore_cert_errors.sql
@@ -1,7 +1,7 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE smtp ADD COLUMN ignore_cert_errors BOOLEAN;
+ALTER TABLE `smtp` ADD COLUMN ignore_cert_errors BOOLEAN;
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back

--- a/db/db_mysql/migrations/20160217211342_0.1.2_create_from_col_results.sql
+++ b/db/db_mysql/migrations/20160217211342_0.1.2_create_from_col_results.sql
@@ -1,7 +1,7 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE results ADD COLUMN position VARCHAR(255);
+ALTER TABLE `results` ADD COLUMN position VARCHAR(255);
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back

--- a/db/db_mysql/migrations/20160225173824_0.1.2_capture_credentials.sql
+++ b/db/db_mysql/migrations/20160225173824_0.1.2_capture_credentials.sql
@@ -1,8 +1,8 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE pages ADD COLUMN capture_credentials BOOLEAN;
-ALTER TABLE pages ADD COLUMN capture_passwords BOOLEAN;
+ALTER TABLE `pages` ADD COLUMN capture_credentials BOOLEAN;
+ALTER TABLE `pages` ADD COLUMN capture_passwords BOOLEAN;
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back

--- a/db/db_mysql/migrations/20160227180335_0.1.2_store-smtp-settings.sql
+++ b/db/db_mysql/migrations/20160227180335_0.1.2_store-smtp-settings.sql
@@ -2,10 +2,10 @@
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
 -- Move the relationship between campaigns and smtp to campaigns
-ALTER TABLE campaigns ADD COLUMN smtp_id bigint;
+ALTER TABLE `campaigns` ADD COLUMN smtp_id bigint;
 -- Create a new table to store smtp records
-DROP TABLE smtp;
-CREATE TABLE smtp(
+DROP TABLE `smtp`;
+CREATE TABLE `smtp`(
 	id integer primary key auto_increment,
 	user_id bigint,
 	interface_type varchar(255),

--- a/db/db_mysql/migrations/20160317214457_0.2_redirect_url.sql
+++ b/db/db_mysql/migrations/20160317214457_0.2_redirect_url.sql
@@ -1,7 +1,7 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE pages ADD COLUMN redirect_url VARCHAR(255);
+ALTER TABLE `pages` ADD COLUMN redirect_url VARCHAR(255);
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back

--- a/db/db_mysql/migrations/20161202153627_AttachmentFix.sql
+++ b/db/db_mysql/migrations/20161202153627_AttachmentFix.sql
@@ -1,9 +1,9 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE attachments MODIFY content LONGTEXT;
+ALTER TABLE `attachments` MODIFY content LONGTEXT;
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
 
-ALTER TABLE attachments MODIFY content TEXT;
+ALTER TABLE `attachments` MODIFY content TEXT;

--- a/db/db_mysql/migrations/20170104231222_0.2_result_statuses.sql
+++ b/db/db_mysql/migrations/20170104231222_0.2_result_statuses.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-UPDATE results
+UPDATE `results`
 SET status = "Submitted Data"
 WHERE id IN (
         SELECT results_tmp.id
@@ -10,7 +10,7 @@ WHERE id IN (
                 AND results_tmp.email = events.email
                 AND results_tmp.campaign_id = events.campaign_id);
 
-UPDATE results
+UPDATE `results`
 SET status = "Clicked Link"
 WHERE id IN (
         SELECT results_tmp.id

--- a/db/db_mysql/migrations/20170219122503_0.2.1_email_headers.sql
+++ b/db/db_mysql/migrations/20170219122503_0.2.1_email_headers.sql
@@ -1,7 +1,7 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-CREATE TABLE IF NOT EXISTS headers(
+CREATE TABLE IF NOT EXISTS `headers` (
 	id integer primary key auto_increment,
 	`key` varchar(255),
 	`value` varchar(255),
@@ -9,4 +9,4 @@ CREATE TABLE IF NOT EXISTS headers(
 );
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
-DROP TABLE headers;
+DROP TABLE `headers`;

--- a/db/db_mysql/migrations/20170828220440_0.4_utc_dates.sql
+++ b/db/db_mysql/migrations/20170828220440_0.4_utc_dates.sql
@@ -1,14 +1,14 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-UPDATE campaigns SET `created_date`=CONVERT_TZ(`created_date`, @@session.time_zone, '+00:00');
-UPDATE campaigns SET `completed_date`=CONVERT_TZ(`completed_date`, @@session.time_zone, '+00:00');
-UPDATE campaigns SET `launch_date`=CONVERT_TZ(`launch_date`, @@session.time_zone, '+00:00');
-UPDATE events SET `time`=CONVERT_TZ(`time`, @@session.time_zone, '+00:00');
-UPDATE groups SET `modified_date`=CONVERT_TZ(`modified_date`, @@session.time_zone, '+00:00');
-UPDATE templates SET `modified_date`=CONVERT_TZ(`modified_date`, @@session.time_zone, '+00:00');
-UPDATE pages SET `modified_date`=CONVERT_TZ(`modified_date`, @@session.time_zone, '+00:00');
-UPDATE smtp SET `modified_date`=CONVERT_TZ(`modified_date`, @@session.time_zone, '+00:00');
+UPDATE `campaigns` SET `created_date`=CONVERT_TZ(`created_date`, @@session.time_zone, '+00:00');
+UPDATE `campaigns` SET `completed_date`=CONVERT_TZ(`completed_date`, @@session.time_zone, '+00:00');
+UPDATE `campaigns` SET `launch_date`=CONVERT_TZ(`launch_date`, @@session.time_zone, '+00:00');
+UPDATE `events` SET `time`=CONVERT_TZ(`time`, @@session.time_zone, '+00:00');
+UPDATE `groups` SET `modified_date`=CONVERT_TZ(`modified_date`, @@session.time_zone, '+00:00');
+UPDATE `templates` SET `modified_date`=CONVERT_TZ(`modified_date`, @@session.time_zone, '+00:00');
+UPDATE `pages` SET `modified_date`=CONVERT_TZ(`modified_date`, @@session.time_zone, '+00:00');
+UPDATE `smtp` SET `modified_date`=CONVERT_TZ(`modified_date`, @@session.time_zone, '+00:00');
 
 
 -- +goose Down

--- a/db/db_mysql/migrations/20171027213457_0.4.1_maillogs.sql
+++ b/db/db_mysql/migrations/20171027213457_0.4.1_maillogs.sql
@@ -1,15 +1,15 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-CREATE TABLE IF NOT EXISTS mail_logs (
-    id integer primary key auto_increment,
-    campaign_id integer,
-    user_id integer,
-    send_date datetime,
-    send_attempt integer,
-    r_id varchar(255),
-    processing boolean);
+CREATE TABLE IF NOT EXISTS `mail_logs` (
+    `id` integer primary key auto_increment,
+    `campaign_id` integer,
+    `user_id` integer,
+    `send_date` datetime,
+    `send_attempt` integer,
+    `r_id` varchar(255),
+    `processing` boolean);
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
-DROP TABLE mail_logs;
+DROP TABLE `mail_logs`;

--- a/db/db_mysql/migrations/20171208201932_0.4.1_next_send_date.sql
+++ b/db/db_mysql/migrations/20171208201932_0.4.1_next_send_date.sql
@@ -1,7 +1,7 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE results ADD COLUMN send_date DATETIME;
+ALTER TABLE `results` ADD COLUMN send_date DATETIME;
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back

--- a/db/db_mysql/migrations/20180223101813_0.5.1_user_reporting.sql
+++ b/db/db_mysql/migrations/20180223101813_0.5.1_user_reporting.sql
@@ -1,7 +1,7 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE results ADD COLUMN reported boolean default 0;
+ALTER TABLE `results` ADD COLUMN reported boolean default 0;
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back

--- a/db/db_mysql/migrations/20180524203752_0.7.0_result_last_modified.sql
+++ b/db/db_mysql/migrations/20180524203752_0.7.0_result_last_modified.sql
@@ -1,9 +1,9 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE results ADD COLUMN modified_date DATETIME;
+ALTER TABLE `results` ADD COLUMN modified_date DATETIME;
 
-UPDATE results
+UPDATE `results`
     SET `modified_date`= (
         SELECT max(events.time) FROM events
         WHERE events.email=results.email

--- a/db/db_mysql/migrations/20180527213648_0.7.0_store_email_request.sql
+++ b/db/db_mysql/migrations/20180527213648_0.7.0_store_email_request.sql
@@ -1,7 +1,7 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-CREATE TABLE IF NOT EXISTS email_requests (
+CREATE TABLE IF NOT EXISTS `email_requests` (
     `id` integer primary key auto_increment,
     `user_id` integer,
     `template_id` integer,
@@ -18,4 +18,4 @@ CREATE TABLE IF NOT EXISTS email_requests (
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
-DROP TABLE email_requests
+DROP TABLE `email_requests`;

--- a/db/db_mysql/migrations/20180609164054_0.7.0_update_html_storage.sql
+++ b/db/db_mysql/migrations/20180609164054_0.7.0_update_html_storage.sql
@@ -1,10 +1,10 @@
 
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
-ALTER TABLE templates MODIFY html MEDIUMTEXT;
-ALTER TABLE pages MODIFY html MEDIUMTEXT;
+ALTER TABLE `templates` MODIFY html MEDIUMTEXT;
+ALTER TABLE `pages` MODIFY html MEDIUMTEXT;
 
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
-ALTER TABLE templates MODIFY html TEXT;
-ALTER TABLE pages MODIFY html TEXT;
+ALTER TABLE `templates` MODIFY html TEXT;
+ALTER TABLE `pages` MODIFY html TEXT;

--- a/db/db_mysql/migrations/20180830215615_0.7.0_send_by_date.sql
+++ b/db/db_mysql/migrations/20180830215615_0.7.0_send_by_date.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 -- SQL in this section is executed when the migration is applied.
-ALTER TABLE campaigns ADD COLUMN send_by_date DATETIME;
+ALTER TABLE `campaigns` ADD COLUMN send_by_date DATETIME;
 
 -- +goose Down
 -- SQL in this section is executed when the migration is rolled back.


### PR DESCRIPTION
Added quotes for table names in MySQL migrations to avoid clashing with reserved keywords introduced in MySQL 8.0 such as "GROUPS". Fixes #1325.