### PR TITLE
Go min version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Gophish: Open-Source Phishing Toolkit
 Installation of Gophish is dead-simple - just download and extract the zip containing the [release for your system](https://github.com/gophish/gophish/releases/), and run the binary. Gophish has binary releases for Windows, Mac, and Linux platforms.
 
 ### Building From Source
-**If you are building from source, please note that Gophish requires Go v1.8 or above!**
+**If you are building from source, please note that Gophish requires Go v1.9 or above!**
 
 To build Gophish from source, simply run ```go get github.com/gophish/gophish``` and ```cd``` into the project source directory. Then, run ```go build```. After this, you should have a binary called ```gophish``` in the current directory.
 


### PR DESCRIPTION
The `github.com/jinzhu/gorm` package uses `sync.Map` which requires go version 1.9