### PR TITLE
Moved api_key from URL to authorization header in requests

### DIFF
--- a/static/js/src/app/gophish.js
+++ b/static/js/src/app/gophish.js
@@ -17,12 +17,15 @@ function modalError(message) {
 
 function query(endpoint, method, data, async) {
     return $.ajax({
-        url: "/api" + endpoint + "?api_key=" + user.api_key,
+        url: "/api" + endpoint,
         async: async,
         method: method,
         data: JSON.stringify(data),
         dataType: "json",
-        contentType: "application/json"
+        contentType: "application/json",
+	beforeSend : function( xhr ) {
+	    xhr.setRequestHeader( 'Authorization', 'Bearer ' + user.api_key );
+	}
     })
 }
 

--- a/static/js/src/app/users.js
+++ b/static/js/src/app/users.js
@@ -87,8 +87,11 @@ function edit(id) {
     }
     // Handle file uploads
     $("#csvupload").fileupload({
-        url: "/api/import/group?api_key=" + user.api_key,
+        url: "/api/import/group",
         dataType: "json",
+	beforeSend : function( xhr ) {
+	    xhr.setRequestHeader( 'Authorization', 'Bearer ' + user.api_key );
+	},
         add: function (e, data) {
             $("#modal\\.flashes").empty()
             var acceptFileTypes = /(csv|txt)$/i;


### PR DESCRIPTION
Hi,

here is the pull request to the issue #1416. The api_key is now no longer used in the request URL but moved to the authorization header. Therefore, the api_key won't show up in any log files anymore. 

A little question off topic: Do you already know when the next GoPhish release is coming? 