### PR TITLE
Prevent adding an empty recipient

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -86,6 +86,9 @@ func ParseCSV(r *http.Request) ([]models.Target, error) {
 				pi = i
 			}
 		}
+		if fi == -1 && li == -1 && ei == -1 && pi == -1 {
+			continue
+		}
 		for {
 			record, err := reader.Read()
 			if err == io.EOF {


### PR DESCRIPTION
If the CSV is malformed, parsing it will still add an empty entry to the user table. That patch is to prevent it.