### PR TITLE
Add date parsing and manipulation for e-mail templates

### DIFF
--- a/models/template_context.go
+++ b/models/template_context.go
@@ -77,7 +77,7 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 func ExecuteTemplate(text string, data interface{}) (string, error) {
 	buff := bytes.Buffer{}
 	funcMap := template.FuncMap{
-		"date": time.Parse,
+		"date":     time.Parse,
 		"duration": time.ParseDuration,
 		"location": time.LoadLocation,
 	}

--- a/models/template_context.go
+++ b/models/template_context.go
@@ -78,6 +78,7 @@ func ExecuteTemplate(text string, data interface{}) (string, error) {
 	buff := bytes.Buffer{}
 	funcMap := template.FuncMap{
 		"date": time.Parse,
+		"duration": time.ParseDuration,
 		"location": time.LoadLocation,
 	}
 	tmpl, err := template.New("template").Funcs(funcMap).Parse(text)

--- a/models/template_context.go
+++ b/models/template_context.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path"
 	"text/template"
+	"time"
 )
 
 // TemplateContext is an interface that allows both campaigns and email
@@ -24,6 +25,7 @@ type PhishingTemplateContext struct {
 	TrackingURL string
 	RId         string
 	BaseURL     string
+	Now         time.Time
 	BaseRecipient
 }
 
@@ -66,6 +68,7 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 		Tracker:       "<img alt='' style='display: none' src='" + trackingURL.String() + "'/>",
 		From:          fn,
 		RId:           rid,
+		Now:           time.Now(),
 	}, nil
 }
 
@@ -73,7 +76,11 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 // template body and data.
 func ExecuteTemplate(text string, data interface{}) (string, error) {
 	buff := bytes.Buffer{}
-	tmpl, err := template.New("template").Parse(text)
+	funcMap := template.FuncMap{
+		"date": time.Parse,
+		"location": time.LoadLocation,
+	}
+	tmpl, err := template.New("template").Funcs(funcMap).Parse(text)
 	if err != nil {
 		return buff.String(), err
 	}

--- a/models/template_context_test.go
+++ b/models/template_context_test.go
@@ -43,5 +43,6 @@ func (s *ModelsSuite) TestNewTemplateContext(c *check.C) {
 	expected.Tracker = "<img alt='' style='display: none' src='" + expected.TrackingURL + "'/>"
 	got, err := NewPhishingTemplateContext(ctx, r.BaseRecipient, r.RId)
 	c.Assert(err, check.Equals, nil)
+	expected.Now = got.Now
 	c.Assert(got, check.DeepEquals, expected)
 }


### PR DESCRIPTION
I added a new variable **{{ .Now }}** that contains the return value for time.Now when the template is executed. I also added three helper functions: **date**, **duration** and **location**, which can be used to parse a string into a Time, Duration or Location object, respectively. These changes allow templates to include references to the current (or specified) date and time. Examples:

Default formatting: {{ .Now }}
Custom formatting: {{ .Now.Format "01/02/2006 3:04 PM (MST)" }}
Custom formatting and time zone: {{ (.Now.In (location "Europe/Prague")).Format "01/02/2006 3:04 PM (MST)" }}

Issue #194 and a part of issue #1387 are relevant.