### PR TITLE
added support for encrypted connections to mysql

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	PhishConf      PhishServer   `json:"phish_server"`
 	DBName         string        `json:"db_name"`
 	DBPath         string        `json:"db_path"`
+	DBSSLCaPath    string        `json:"db_sslca_path"`
 	MigrationsPath string        `json:"migrations_prefix"`
 	TestFlag       bool          `json:"test_flag"`
 	ContactAddress string        `json:"contact_address"`


### PR DESCRIPTION
This pull request provides a first pass on a new config option `db_sslca_path` in `config.json` in order to support encrypted connections to a mysql db (see #1456).

If the `db_sslca_path` is present in the configuration and `db_path` includes the query parameters `tls=ssl_ca`, the connection to the mysql db is encrypted using the given public key (which would be provided by the administrator of the db).

If the query string `tls=ssl_ca` is added, even though no `db_sslca_path` is set, the database connection fails in models/models.go#129  (or 102, pre pull request) and the error is presented to the user after `MaxDatabaseConnectionAttempts` attempts.
Specifying a non-existing, unreadable or invalid PEM file would also result in errors in models/models.go#110 and 114.
If the `db_sslca_path` is present but the `db_path` is not adapted, the connection is attempted without using encryption (and may fail, depending on db configuration).

Currently, no attempt is made to check if the `tls` query parameter is set correctly if a `db_sslca_path` is present. This could be done (either by parsing the DSN manually - which I would like to prevent - or by relying on `go-sql-driver/mysql#ParseDSN`).
If we check for the tls parameter, two consequences would be possible:

- Display an error and abort, as the connection would be unencrypted if we continued with a missing `tls` parameter
- Display a warning and continue, as the user might be debugging the config and knowingly removed the `tls` parameter and kept the reference to the CA for later use.

Alternatively, we could of course change nothing on this specific behaviour :)

If you would like this, or any other changes, please let me know.