### PR TITLE
Added response headers for CORS and server identification

### DIFF
--- a/controllers/phish.go
+++ b/controllers/phish.go
@@ -196,7 +196,7 @@ func (ps *PhishingServer) ReportHandler(w http.ResponseWriter, r *http.Request) 
 // (such as clicked link, etc.)
 func (ps *PhishingServer) PhishHandler(w http.ResponseWriter, r *http.Request) {
 	r, err := setupContext(r)
-	w.Header().Set("X-Server", "GoPhish") // Useful for checking if this is a GoPhish server (e.g. for campaign reporting plugins)
+	w.Header().Set("X-Server", config.ServerName) // Useful for checking if this is a GoPhish server (e.g. for campaign reporting plugins)
 	if err != nil {
 		// Log the error if it wasn't something we can safely ignore
 		if err != ErrInvalidRequest && err != ErrCampaignComplete {

--- a/controllers/phish.go
+++ b/controllers/phish.go
@@ -196,8 +196,8 @@ func (ps *PhishingServer) ReportHandler(w http.ResponseWriter, r *http.Request) 
 // (such as clicked link, etc.)
 func (ps *PhishingServer) PhishHandler(w http.ResponseWriter, r *http.Request) {
 	r, err := setupContext(r)
-	w.Header().Set("X-Server", config.ServerName) // Useful for checking if this is a GoPhish server (e.g. for campaign reporting plugins)
 	if err != nil {
+		w.Header().Set("X-Server", config.ServerName) // Useful for checking if this is a GoPhish server (e.g. for campaign reporting plugins)
 		// Log the error if it wasn't something we can safely ignore
 		if err != ErrInvalidRequest && err != ErrCampaignComplete {
 			log.Error(err)

--- a/controllers/phish.go
+++ b/controllers/phish.go
@@ -161,6 +161,7 @@ func (ps *PhishingServer) TrackHandler(w http.ResponseWriter, r *http.Request) {
 // ReportHandler tracks emails as they are reported, updating the status for the given Result
 func (ps *PhishingServer) ReportHandler(w http.ResponseWriter, r *http.Request) {
 	r, err := setupContext(r)
+	w.Header().Set("Access-Control-Allow-Origin", "*") // To allow Chrome extensions (or other pages) to report a campaign without violating CORS
 	if err != nil {
 		// Log the error if it wasn't something we can safely ignore
 		if err != ErrInvalidRequest && err != ErrCampaignComplete {
@@ -195,6 +196,7 @@ func (ps *PhishingServer) ReportHandler(w http.ResponseWriter, r *http.Request) 
 // (such as clicked link, etc.)
 func (ps *PhishingServer) PhishHandler(w http.ResponseWriter, r *http.Request) {
 	r, err := setupContext(r)
+	w.Header().Set("X-Server", "GoPhish") // Useful for checking if this is a GoPhish server (e.g. for campaign reporting plugins)
 	if err != nil {
 		// Log the error if it wasn't something we can safely ignore
 		if err != ErrInvalidRequest && err != ErrCampaignComplete {


### PR DESCRIPTION
Added _"Access-Control-Allow-Origin": "*"_ to the **ReportHandler** to allow reporting extensions to bypass CORS restrictions.

Added _"X-Server": "GoPhish"_ to the **PhishHandler** endpoint to assist in identifying a server as a GoPhish server.