### PR TITLE
Embed or attach files based on their file extension

### DIFF
--- a/models/email_request.go
+++ b/models/email_request.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/mail"
-	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/gophish/gomail"
@@ -182,7 +180,7 @@ func (s *EmailRequest) Generate(msg *gomail.Message) error {
 				return err
 			}
 		}(a))
-		if sort.SearchStrings(EmbeddedFileExtensions, filepath.Ext(a.Name)) < len(EmbeddedFileExtensions) {
+		if shouldEmbedAttachment(a.Name) {
 			msg.Embed(a.Name, copyFunc)
 		} else {
 			msg.Attach(a.Name, copyFunc)

--- a/models/email_request.go
+++ b/models/email_request.go
@@ -168,9 +168,10 @@ func (s *EmailRequest) Generate(msg *gomail.Message) error {
 			msg.AddAlternative("text/html", html)
 		}
 	}
+
 	// Attach the files
 	for _, a := range s.Template.Attachments {
-		addAttachment(msg, a)
+		addAttachment(msg, a, ptx)
 	}
 
 	return nil

--- a/models/email_request.go
+++ b/models/email_request.go
@@ -1,11 +1,8 @@
 package models
 
 import (
-	"encoding/base64"
 	"fmt"
-	"io"
 	"net/mail"
-	"strings"
 
 	"github.com/gophish/gomail"
 	"github.com/gophish/gophish/config"
@@ -173,18 +170,7 @@ func (s *EmailRequest) Generate(msg *gomail.Message) error {
 	}
 	// Attach the files
 	for _, a := range s.Template.Attachments {
-		copyFunc := gomail.SetCopyFunc(func(c Attachment) func(w io.Writer) error {
-			return func(w io.Writer) error {
-				decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(c.Content))
-				_, err = io.Copy(w, decoder)
-				return err
-			}
-		}(a))
-		if shouldEmbedAttachment(a.Name) {
-			msg.Embed(a.Name, copyFunc)
-		} else {
-			msg.Attach(a.Name, copyFunc)
-		}
+		addAttachment(msg, a)
 	}
 
 	return nil

--- a/models/maillog.go
+++ b/models/maillog.go
@@ -11,7 +11,6 @@ import (
 	"net/mail"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -30,7 +29,7 @@ var MaxSendAttempts = 8
 var ErrMaxSendAttempts = errors.New("max send attempts exceeded")
 
 // Attachments with these file extensions have inline disposition
-var EmbeddedFileExtensions = []string{".jpg", ".jpeg", ".png", ".gif"}
+var embeddedFileExtensions = []string{".jpg", ".jpeg", ".png", ".gif"}
 
 // MailLog is a struct that holds information about an email that is to be
 // sent out.
@@ -266,7 +265,7 @@ func (m *MailLog) Generate(msg *gomail.Message) error {
 				return err
 			}
 		}(a))
-		if sort.SearchStrings(EmbeddedFileExtensions, filepath.Ext(a.Name)) < len(EmbeddedFileExtensions) {
+		if shouldEmbedAttachment(a.Name) {
 			msg.Embed(a.Name, copyFunc)
 		} else {
 			msg.Attach(a.Name, copyFunc)
@@ -341,4 +340,16 @@ func (m *MailLog) generateMessageID() (string, error) {
 	}
 	msgid := fmt.Sprintf("<%d.%d.%d@%s>", t, pid, rint, h)
 	return msgid, nil
+}
+
+// Check if an attachment should have inline disposition based on
+// its file extension.
+func shouldEmbedAttachment(name string) bool {
+	ext := filepath.Ext(name)
+	for _, v := range embeddedFileExtensions {
+		if strings.EqualFold(ext, v) {
+			return true
+		}
+	}
+	return false
 }

--- a/models/maillog_test.go
+++ b/models/maillog_test.go
@@ -360,6 +360,50 @@ func (s *ModelsSuite) TestMailLogGenerateEmptySubject(ch *check.C) {
 	ch.Assert(got.Subject, check.Equals, expected.Subject)
 }
 
+func (s *ModelsSuite) TestShouldEmbedAttachment(ch *check.C) {
+
+	// Supported file extensions
+	ch.Assert(shouldEmbedAttachment(".png"), check.Equals, true)
+	ch.Assert(shouldEmbedAttachment(".jpg"), check.Equals, true)
+	ch.Assert(shouldEmbedAttachment(".jpeg"), check.Equals, true)
+	ch.Assert(shouldEmbedAttachment(".gif"), check.Equals, true)
+
+	// Some other file extensions
+	ch.Assert(shouldEmbedAttachment(".docx"), check.Equals, false)
+	ch.Assert(shouldEmbedAttachment(".txt"), check.Equals, false)
+	ch.Assert(shouldEmbedAttachment(".jar"), check.Equals, false)
+	ch.Assert(shouldEmbedAttachment(".exe"), check.Equals, false)
+
+	// Invalid input
+	ch.Assert(shouldEmbedAttachment(""), check.Equals, false)
+	ch.Assert(shouldEmbedAttachment("png"), check.Equals, false)
+}
+
+func (s *ModelsSuite) TestEmbedAttachment(ch *check.C) {
+	campaign := s.createCampaignDependencies(ch)
+	campaign.Template.Attachments = []Attachment{
+		{
+			Name:    "test.png",
+			Type:    "image/png",
+			Content: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=",
+		},
+		{
+			Name:    "test.txt",
+			Type:    "text/plain",
+			Content: "VGVzdCB0ZXh0IGZpbGU=",
+		},
+	}
+	PutTemplate(&campaign.Template)
+	ch.Assert(PostCampaign(&campaign, campaign.UserId), check.Equals, nil)
+	got := s.emailFromFirstMailLog(campaign, ch)
+
+	// The email package simply ignores attachments where the Content-Disposition header is set
+	// to inline, so the best we can do without replacing the whole thing is to check that only
+	// the text file was added as an attachment.
+	ch.Assert(got.Attachments, check.HasLen, 1)
+	ch.Assert(got.Attachments[0].Filename, check.Equals, "test.txt")
+}
+
 func BenchmarkMailLogGenerate100(b *testing.B) {
 	setupBenchmark(b)
 	campaign := setupCampaign(b, 100)


### PR DESCRIPTION
There have been a few discussions about embedding images in e-mails (#251, #884). As it is right now, while Content-IDs were added, the Content-Disposition header was still set to attachment for all files, and as such, e-mail clients showed them as attached files. My proposed solution makes the judgement on whether a file should be embedded or attached based on its extension - jpg, jpeg, png and gif files are embedded (and have a Content-ID set), while other file types are attached. 

It might be better on the long run to offer a checkbox to set whether a file should be attached or embedded, but I believe that 99% of the time images are only added to a message to be shown inline. With these changes, adding images to a message will work as expected, while other files can still be added as attachments.