### PR TITLE
Remove not working link for non admin role users

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -47,8 +47,10 @@
                     </li>
                     <li><a href="/campaigns">Campaigns</a>
                     </li>
+		    {{if .ModifySystem}}
                     <li><a href="/users">Users &amp; Groups</a>
                     </li>
+		    {{end}}
                     <li><a href="/templates">Email Templates</a>
                     </li>
                     <li><a href="/landing_pages">Landing Pages</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -43,22 +43,6 @@
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav navbar-right">
-                    <li><a href="/">Dashboard</a>
-                    </li>
-                    <li><a href="/campaigns">Campaigns</a>
-                    </li>
-		    {{if .ModifySystem}}
-                    <li><a href="/users">Users &amp; Groups</a>
-                    </li>
-		    {{end}}
-                    <li><a href="/templates">Email Templates</a>
-                    </li>
-                    <li><a href="/landing_pages">Landing Pages</a>
-                    </li>
-                    <li><a href="/sending_profiles">Sending Profiles</a>
-                    </li>
-                    <li><a href="/settings">Settings</a>
-                    </li>
                     <li>
                         {{if .User}}
                         <div class="btn-group" id="navbar-dropdown">


### PR DESCRIPTION
Users&Group link in the top menu to access the user management page should not be displayed for non admin role users.