### PR TITLE
Import email templates from file

### DIFF
--- a/controllers/api/import.go
+++ b/controllers/api/import.go
@@ -49,6 +49,44 @@ func (as *Server) ImportGroup(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
+// ImportEmailFile allows for the importing of email.
+// Returns a Message object
+func (as *Server) ImportEmailFile(w http.ResponseWriter, r *http.Request) {
+
+	if r.Method != "POST" {
+		JSONResponse(w, models.Response{Success: false, Message: "Method not allowed"}, http.StatusBadRequest)
+		return
+	}
+	mr, nil := r.MultipartReader()
+	part, nil := mr.NextPart()
+	e, err := email.NewEmailFromReader(part)
+	if err != nil {
+		log.Error(err)
+	}
+	d, err := goquery.NewDocumentFromReader(bytes.NewReader(e.HTML))
+	if err != nil {
+		JSONResponse(w, models.Response{Success: false, Message: err.Error()}, http.StatusBadRequest)
+		return
+	}
+	d.Find("a").Each(func(i int, a *goquery.Selection) {
+		a.SetAttr("href", "{{.URL}}")
+	})
+	h, err := d.Html()
+	if err != nil {
+		JSONResponse(w, models.Response{Success: false, Message: err.Error()}, http.StatusInternalServerError)
+		return
+	}
+	e.HTML = []byte(h)
+
+	er := emailResponse{
+		Subject: e.Subject,
+		Text:    string(e.Text),
+		HTML:    string(e.HTML),
+	}
+	JSONResponse(w, er, http.StatusOK)
+	return
+}
+
 // ImportEmail allows for the importing of email.
 // Returns a Message object
 func (as *Server) ImportEmail(w http.ResponseWriter, r *http.Request) {

--- a/controllers/api/server.go
+++ b/controllers/api/server.go
@@ -70,6 +70,7 @@ func (as *Server) registerRoutes() {
 	router.HandleFunc("/util/send_test_email", as.SendTestEmail)
 	router.HandleFunc("/import/group", as.ImportGroup)
 	router.HandleFunc("/import/email", as.ImportEmail)
+	router.HandleFunc("/import/emailfile", as.ImportEmailFile)
 	router.HandleFunc("/import/site", as.ImportSite)
 	as.handler = router
 }

--- a/static/js/src/app/templates.js
+++ b/static/js/src/app/templates.js
@@ -213,6 +213,36 @@ function edit(idx) {
             .remove()
             .draw();
     })
+
+    // Handle file uploads
+    $("#emlupload").fileupload({
+        url: "/api/import/emailfile",
+        dataType: "json",
+        beforeSend: function (xhr) {
+            xhr.setRequestHeader('Authorization', 'Bearer ' + user.api_key);
+        },
+        add: function (e, data) {
+            $("#modal\\.flashes").empty()
+            var acceptFileTypes = /(eml)$/i;
+            var filename = data.originalFiles[0]['name']
+            if (filename && !acceptFileTypes.test(filename.split(".").pop())) {
+                modalError("Unsupported file extension (use .eml)")
+                return false;
+            }
+            data.submit();
+        },
+        success: function (data) {
+            $("#text_editor").val(data.text)
+            $("#html_editor").val(data.html)
+            $("#subject").val(data.subject)
+            // If the HTML is provided, let's open that view in the editor
+            if (data.html) {
+                CKEDITOR.instances["html_editor"].setMode('wysiwyg')
+                $('.nav-tabs a[href="#html"]').click()
+            }
+            $("#importEmailModal").modal("hide")
+        }
+    })
 }
 
 function copy(idx) {

--- a/templates/templates.html
+++ b/templates/templates.html
@@ -52,8 +52,11 @@
                 </div>
                 <div class="form-group">
                     <button class="btn btn-danger" data-toggle="modal" data-backdrop="static" data-target="#importEmailModal"><i
-                            class="fa fa-envelope"></i>
-                        Import Email</button>
+                            class="fa fa-paste"></i>
+                        Paste Raw Email</button>
+                    <button class="btn btn-danger btn-file" data-toggle="tooltip" data-placement="right" title="Supports EML files" id="fileUpload"><i
+                            class="fa fa-file"></i>
+                        Import Email File<input type="file" id="emlupload"></button>
                 </div>
                 <label class="control-label" for="subject">Subject:</label>
                 <div class="form-group">


### PR DESCRIPTION
The idea is to add a new button "Import Email File" to let the users upload a local EML file, it's easier to manage if you have multiple EML templates. The previous button is still here but has been renamed "Paste Raw Email".