### PR TITLE
Exit on port binding failure

### DIFF
--- a/controllers/phish.go
+++ b/controllers/phish.go
@@ -82,19 +82,18 @@ func WithContactAddress(addr string) PhishingServerOption {
 }
 
 // Start launches the phishing server, listening on the configured address.
-func (ps *PhishingServer) Start() error {
+func (ps *PhishingServer) Start() {
 	if ps.config.UseTLS {
 		err := util.CheckAndCreateSSL(ps.config.CertPath, ps.config.KeyPath)
 		if err != nil {
 			log.Fatal(err)
-			return err
 		}
 		log.Infof("Starting phishing server at https://%s", ps.config.ListenURL)
-		return ps.server.ListenAndServeTLS(ps.config.CertPath, ps.config.KeyPath)
+		log.Fatal(ps.server.ListenAndServeTLS(ps.config.CertPath, ps.config.KeyPath))
 	}
 	// If TLS isn't configured, just listen on HTTP
 	log.Infof("Starting phishing server at http://%s", ps.config.ListenURL)
-	return ps.server.ListenAndServe()
+	log.Fatal(ps.server.ListenAndServe())
 }
 
 // Shutdown attempts to gracefully shutdown the server.

--- a/controllers/route.go
+++ b/controllers/route.go
@@ -65,7 +65,7 @@ func NewAdminServer(config config.AdminServer, options ...AdminServerOption) *Ad
 }
 
 // Start launches the admin server, listening on the configured address.
-func (as *AdminServer) Start() error {
+func (as *AdminServer) Start() {
 	if as.worker != nil {
 		go as.worker.Start()
 	}
@@ -73,14 +73,13 @@ func (as *AdminServer) Start() error {
 		err := util.CheckAndCreateSSL(as.config.CertPath, as.config.KeyPath)
 		if err != nil {
 			log.Fatal(err)
-			return err
 		}
 		log.Infof("Starting admin server at https://%s", as.config.ListenURL)
-		return as.server.ListenAndServeTLS(as.config.CertPath, as.config.KeyPath)
+		log.Fatal(as.server.ListenAndServeTLS(as.config.CertPath, as.config.KeyPath))
 	}
 	// If TLS isn't configured, just listen on HTTP
 	log.Infof("Starting admin server at http://%s", as.config.ListenURL)
-	return as.server.ListenAndServe()
+	log.Fatal(as.server.ListenAndServe())
 }
 
 // Shutdown attempts to gracefully shutdown the server.


### PR DESCRIPTION
There have been a few issues raised recently with people trying to bind to port 80 without root permissions, as Gophish currently fails silently on this condition.

For this pull request I wrapped `log.Fatal()` around the various `ListenAndServe` functions. Also removed the `error` return as log.Fatal will immediately exit.