### PR TITLE
Bugfix Issue 1570

### DIFF
--- a/models/template_context.go
+++ b/models/template_context.go
@@ -45,7 +45,10 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 
 	// For the base URL, we'll reset the the path and the query
 	// This will create a URL in the form of http://example.com
-	baseURL, _ := url.Parse(templateURL)
+	baseURL, err:= url.Parse(templateURL)
+	if err != nil {
+		return PhishingTemplateContext{}, err
+	}
 	baseURL.Path = ""
 	baseURL.RawQuery = ""
 


### PR DESCRIPTION
Regarding Issue 1570 (https://github.com/gophish/gophish/issues/1570) "gophish getting crashed automatically": This could happen to anybody. Any User of an instance could terminate the whole gophish process. This could badly influence other actual running campaigns. This fix will prevent gophish from terminating, when a template is deleted while mails still scheduled.
