### PR TITLE
1624 - Return API Key on Password Change

### DIFF
--- a/controllers/api/user.go
+++ b/controllers/api/user.go
@@ -115,7 +115,7 @@ func (as *Server) Users(w http.ResponseWriter, r *http.Request) {
 			JSONResponse(w, models.Response{Success: false, Message: err.Error()}, http.StatusInternalServerError)
 			return
 		}
-		JSONResponse(w, models.ChangedUser(user), http.StatusOK)
+		JSONResponse(w, user, http.StatusOK)
 		return
 	}
 }
@@ -213,6 +213,6 @@ func (as *Server) User(w http.ResponseWriter, r *http.Request) {
 			JSONResponse(w, models.Response{Success: false, Message: err.Error()}, http.StatusInternalServerError)
 			return
 		}
-		JSONResponse(w, models.ChangedUser(existingUser), http.StatusOK)
+		JSONResponse(w, existingUser, http.StatusOK)
 	}
 }

--- a/controllers/api/user.go
+++ b/controllers/api/user.go
@@ -115,7 +115,7 @@ func (as *Server) Users(w http.ResponseWriter, r *http.Request) {
 			JSONResponse(w, models.Response{Success: false, Message: err.Error()}, http.StatusInternalServerError)
 			return
 		}
-		JSONResponse(w, user, http.StatusOK)
+		JSONResponse(w, models.ChangedUser(user), http.StatusOK)
 		return
 	}
 }
@@ -213,6 +213,6 @@ func (as *Server) User(w http.ResponseWriter, r *http.Request) {
 			JSONResponse(w, models.Response{Success: false, Message: err.Error()}, http.StatusInternalServerError)
 			return
 		}
-		JSONResponse(w, existingUser, http.StatusOK)
+		JSONResponse(w, models.ChangedUser(existingUser), http.StatusOK)
 	}
 }

--- a/models/user.go
+++ b/models/user.go
@@ -21,20 +21,6 @@ type User struct {
 	RoleID   int64  `json:"-"`
 }
 
-// Changed User is identical to a regular user except that it contains the API key in
-// the serialized response. This is desirable in case GoPhish is used via API with multiple
-// users, otherwise there are no means of retrieving the API key of a newly created user.
-// This type is only supposed to be used for JSON serialization, so there is no need for 
-// having database associations.
-type ChangedUser struct {
-	Id       int64  `json:"id"`
-	Username string `json:"username"`
-	Hash     string `json:"-"`
-	ApiKey   string `json:"api"` 
-	Role     Role   `json:"role"`
-	RoleID   int64  `json:"-"`
-}
-
 // GetUser returns the user that the given id corresponds to. If no user is found, an
 // error is thrown.
 func GetUser(id int64) (User, error) {

--- a/models/user.go
+++ b/models/user.go
@@ -16,7 +16,7 @@ type User struct {
 	Id       int64  `json:"id"`
 	Username string `json:"username" sql:"not null;unique"`
 	Hash     string `json:"-"`
-	ApiKey   string `json:"api" sql:"not null;unique"`
+	ApiKey   string `json:"api_key" sql:"not null;unique"`
 	Role     Role   `json:"role" gorm:"association_autoupdate:false;association_autocreate:false"`
 	RoleID   int64  `json:"-"`
 }

--- a/models/user.go
+++ b/models/user.go
@@ -16,7 +16,7 @@ type User struct {
 	Id       int64  `json:"id"`
 	Username string `json:"username" sql:"not null;unique"`
 	Hash     string `json:"-"`
-	ApiKey   string `json:"-" sql:"not null;unique"`
+	ApiKey   string `json:"api" sql:"not null;unique"`
 	Role     Role   `json:"role" gorm:"association_autoupdate:false;association_autocreate:false"`
 	RoleID   int64  `json:"-"`
 }

--- a/models/user.go
+++ b/models/user.go
@@ -21,6 +21,20 @@ type User struct {
 	RoleID   int64  `json:"-"`
 }
 
+// Changed User is identical to a regular user except that it contains the API key in
+// the serialized response. This is desirable in case GoPhish is used via API with multiple
+// users, otherwise there are no means of retrieving the API key of a newly created user.
+// This type is only supposed to be used for JSON serialization, so there is no need for 
+// having database associations.
+type ChangedUser struct {
+	Id       int64  `json:"id"`
+	Username string `json:"username"`
+	Hash     string `json:"-"`
+	ApiKey   string `json:"api"` 
+	Role     Role   `json:"role"`
+	RoleID   int64  `json:"-"`
+}
+
 // GetUser returns the user that the given id corresponds to. If no user is found, an
 // error is thrown.
 func GetUser(id int64) (User, error) {


### PR DESCRIPTION
Fix for #1624 

The idea is to create a second user type that allows to marshal the API key to JSON but is not serialized to the database.

In case a user is created or altered via API, the regular `models.User` object is converted to a `models.ChangedUser` before serialization, making the API key available to the issuer of the request.

Quick demo:

~~~bash
~  curl -k -XGET 'https://localhost:3333/api/users/' -H 'Authorization: b07c553b82b6aedfa4c7107c8f2b81854dc4d4c85e66c09fe77055a285c660d7'
[
  {
    "id": 1,
    "username": "admin",
    "role": {
      "slug": "admin",
      "name": "Admin",
      "description": "System administrator with full permissions"
    }
  }
]
~  curl -k -XPOST 'https://localhost:3333/api/users/' -H "Content-Type: application/json" -H 'Authorization: b07c553b82b6aedfa4c7107c8f2b81854dc4d4c85e66c09fe77055a285c660d7' -d '{"role": "admin", "username": "test", "password": "NotSoSecure123!"}'
{
  "id": 2,
  "username": "test",
  "api": "f0ad4dc056eb47041ea3293cb8bce2399fc81ec26e9a3a8cdc0c5f6aabfed140",
  "role": {
    "slug": "admin",
    "name": "Admin",
    "description": "System administrator with full permissions"
  }
}
~  curl -k -XGET 'https://localhost:3333/api/users/' -H 'Authorization: f0ad4dc056eb47041ea3293cb8bce2399fc81ec26e9a3a8cdc0c5f6aabfed140'
[
  {
    "id": 1,
    "username": "admin",
    "role": {
      "slug": "admin",
      "name": "Admin",
      "description": "System administrator with full permissions"
    }
  },
  {
    "id": 2,
    "username": "test",
    "role": {
      "slug": "admin",
      "name": "Admin",
      "description": "System administrator with full permissions"
    }
  }
]
~~~

I tried to keep the change as small and concise as possible, feedback is nevertheless appreciated.
I'd love to see this merged, after approval I'd update the API documentation as well to reflect the change.