### PR TITLE
Allow CORS to be configured for API requests

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,11 @@
 		"listen_url": "127.0.0.1:3333",
 		"use_tls": true,
 		"cert_path": "gophish_admin.crt",
-		"key_path": "gophish_admin.key"
+		"key_path": "gophish_admin.key",
+		"api": {
+			"cors_allowed_origins": ["*"],
+			"cors_debug": false
+		}
 	},
 	"phish_server": {
 		"listen_url": "0.0.0.0:80",

--- a/config/config.go
+++ b/config/config.go
@@ -5,12 +5,19 @@ import (
 	"io/ioutil"
 )
 
+// ApiServer represents the API server configuration details
+type ApiServer struct {
+	CorsAllowedOrigins []string `json:"cors_allowed_origins"`
+	CorsDebug          bool     `json:"cors_debug"`
+}
+
 // AdminServer represents the Admin server configuration details
 type AdminServer struct {
-	ListenURL string `json:"listen_url"`
-	UseTLS    bool   `json:"use_tls"`
-	CertPath  string `json:"cert_path"`
-	KeyPath   string `json:"key_path"`
+	ListenURL string    `json:"listen_url"`
+	UseTLS    bool      `json:"use_tls"`
+	CertPath  string    `json:"cert_path"`
+	KeyPath   string    `json:"key_path"`
+	ApiConf   ApiServer `json:"api"`
 }
 
 // PhishServer represents the Phish server configuration details

--- a/controllers/api/api_test.go
+++ b/controllers/api/api_test.go
@@ -43,7 +43,7 @@ func (s *APISuite) SetupSuite() {
 	// static assets
 	err = os.Chdir("../")
 	s.Nil(err)
-	s.apiServer = NewServer()
+	s.apiServer = NewServer(conf.AdminConf.ApiConf)
 }
 
 func (s *APISuite) TearDownTest() {

--- a/controllers/api/server.go
+++ b/controllers/api/server.go
@@ -79,9 +79,9 @@ func (as *Server) registerRoutes() {
 	c := cors.New(cors.Options{
 		AllowedOrigins: as.config.CorsAllowedOrigins,
 		AllowedMethods: []string{"GET", "POST", "OPTIONS"},
-		AllowedHeaders: []string{"Origin", "X-Requested-With", "Content-Type", "Accept"},
+		AllowedHeaders: []string{"Origin", "X-Requested-With", "Content-Type", "Accept", "Authorization"},
 		MaxAge: 1000,
-		AllowCredentials: true,
+		AllowCredentials: false,
 		Debug: as.config.CorsDebug,
 	})
 	

--- a/controllers/route.go
+++ b/controllers/route.go
@@ -106,7 +106,7 @@ func (as *AdminServer) registerRoutes() {
 	router.HandleFunc("/settings", mid.Use(as.Settings, mid.RequireLogin))
 	router.HandleFunc("/users", mid.Use(as.UserManagement, mid.RequirePermission(models.PermissionModifySystem), mid.RequireLogin))
 	// Create the API routes
-	api := api.NewServer(api.WithWorker(as.worker))
+	api := api.NewServer(as.config.ApiConf, api.WithWorker(as.worker))
 	router.PathPrefix("/api/").Handler(api)
 
 	// Setup static file serving

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -75,13 +75,6 @@ func GetContext(handler http.Handler) http.HandlerFunc {
 // parameter, or a Bearer token.
 func RequireAPIKey(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		if r.Method == "OPTIONS" {
-			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
-			w.Header().Set("Access-Control-Max-Age", "1000")
-			w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
-			return
-		}
 		r.ParseForm()
 		ak := r.Form.Get("api_key")
 		// If we can't get the API key, we'll also check for the


### PR DESCRIPTION
Currently we're building an application that calls the Gophish API using XHR and ran into CORS. This PR adds proper support for CORS with preflight and I have added configuration options to customise the allowed origins as well as to toggle debug mode. CORS is only handled for the API endpoints and I have set the default to allow all origins.

It should probably be mentioned in the documentation that this should be set to a more strict set of hosts or even to the hostname of the Gophish server.

It would be really helpful if this functionality was added so we don't have to rely on the webserver configuration injecting the CORS headers.

Please let me know if anything is missing.