### PR TITLE
Updated Docker Hub link to point to gophish/gophish

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installation of Gophish is dead-simple - just download and extract the zip conta
 To build Gophish from source, simply run ```go get github.com/gophish/gophish``` and ```cd``` into the project source directory. Then, run ```go build```. After this, you should have a binary called ```gophish``` in the current directory.
 
 ### Docker
-You can also use Gophish via an unofficial Docker container [here](https://hub.docker.com/r/matteoggl/gophish/).
+You can also use Gophish via an unofficial Docker container [here](https://hub.docker.com/r/gophish/gophish/).
 
 ### Setup
 After running the Gophish binary, open an Internet browser to https://localhost:3333 and login with the default username (admin) and password (gophish).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installation of Gophish is dead-simple - just download and extract the zip conta
 To build Gophish from source, simply run ```go get github.com/gophish/gophish``` and ```cd``` into the project source directory. Then, run ```go build```. After this, you should have a binary called ```gophish``` in the current directory.
 
 ### Docker
-You can also use Gophish via an unofficial Docker container [here](https://hub.docker.com/r/gophish/gophish/).
+You can also use Gophish via the official Docker container [here](https://hub.docker.com/r/gophish/gophish/).
 
 ### Setup
 After running the Gophish binary, open an Internet browser to https://localhost:3333 and login with the default username (admin) and password (gophish).


### PR DESCRIPTION
The Readme currently points to https://hub.docker.com/r/matteoggl/gophish/ which is a Docker image that hasn't been updated in over 2 years. This PR updates the Readme link to point to a more current Docker Image.