### PR TITLE
Refactoring tests to remove stretchr/testify dependency

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,15 +4,9 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/suite"
 )
-
-type ConfigSuite struct {
-	suite.Suite
-	ConfigFile *os.File
-}
 
 var validConfig = []byte(`{
 	"admin_server": {
@@ -33,36 +27,48 @@ var validConfig = []byte(`{
 	"contact_address": ""
 }`)
 
-func (s *ConfigSuite) SetupTest() {
+func createTemporaryConfig(t *testing.T) *os.File {
 	f, err := ioutil.TempFile("", "gophish-config")
-	s.Nil(err)
-	s.ConfigFile = f
+	if err != nil {
+		t.Fatalf("unable to create temporary config: %v", err)
+	}
+	return f
 }
 
-func (s *ConfigSuite) TearDownTest() {
-	err := s.ConfigFile.Close()
-	s.Nil(err)
+func removeTemporaryConfig(t *testing.T, f *os.File) {
+	err := f.Close()
+	if err != nil {
+		t.Fatalf("unable to remove temporary config: %v", err)
+	}
 }
 
-func (s *ConfigSuite) TestLoadConfig() {
-	_, err := s.ConfigFile.Write(validConfig)
-	s.Nil(err)
+func TestLoadConfig(t *testing.T) {
+	f := createTemporaryConfig(t)
+	defer removeTemporaryConfig(t, f)
+	_, err := f.Write(validConfig)
+	if err != nil {
+		t.Fatalf("error writing config to temporary file: %v", err)
+	}
 	// Load the valid config
-	conf, err := LoadConfig(s.ConfigFile.Name())
-	s.Nil(err)
+	conf, err := LoadConfig(f.Name())
+	if err != nil {
+		t.Fatalf("error loading config from temporary file: %v", err)
+	}
 
 	expectedConfig := &Config{}
 	err = json.Unmarshal(validConfig, &expectedConfig)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error unmarshaling config: %v", err)
+	}
 	expectedConfig.MigrationsPath = expectedConfig.MigrationsPath + expectedConfig.DBName
 	expectedConfig.TestFlag = false
-	s.Equal(expectedConfig, conf)
+	if !reflect.DeepEqual(expectedConfig, conf) {
+		t.Fatalf("invalid config received. expected %#v got %#v", expectedConfig, conf)
+	}
 
 	// Load an invalid config
 	conf, err = LoadConfig("bogusfile")
-	s.NotNil(err)
-}
-
-func TestConfigSuite(t *testing.T) {
-	suite.Run(t, new(ConfigSuite))
+	if err == nil {
+		t.Fatalf("expected error when loading invalid config, but got %v", err)
+	}
 }

--- a/controllers/api/api_test.go
+++ b/controllers/api/api_test.go
@@ -6,23 +6,20 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/gophish/gophish/config"
 	"github.com/gophish/gophish/models"
-	"github.com/stretchr/testify/suite"
 )
 
-type APISuite struct {
-	suite.Suite
+type testContext struct {
 	apiKey    string
 	config    *config.Config
 	apiServer *Server
 	admin     models.User
 }
 
-func (s *APISuite) SetupSuite() {
+func setupTest(t *testing.T) *testContext {
 	conf := &config.Config{
 		DBName:         "sqlite3",
 		DBPath:         ":memory:",
@@ -30,39 +27,34 @@ func (s *APISuite) SetupSuite() {
 	}
 	err := models.Setup(conf)
 	if err != nil {
-		s.T().Fatalf("Failed creating database: %v", err)
+		t.Fatalf("Failed creating database: %v", err)
 	}
-	s.config = conf
-	s.Nil(err)
+	ctx := &testContext{}
+	ctx.config = conf
 	// Get the API key to use for these tests
 	u, err := models.GetUser(1)
-	s.Nil(err)
-	s.apiKey = u.ApiKey
-	s.admin = u
-	// Move our cwd up to the project root for help with resolving
-	// static assets
-	err = os.Chdir("../")
-	s.Nil(err)
-	s.apiServer = NewServer()
+	if err != nil {
+		t.Fatalf("error getting admin user: %v", err)
+	}
+	ctx.apiKey = u.ApiKey
+	ctx.admin = u
+	ctx.apiServer = NewServer()
+	return ctx
 }
 
-func (s *APISuite) TearDownTest() {
-	campaigns, _ := models.GetCampaigns(1)
-	for _, campaign := range campaigns {
-		models.DeleteCampaign(campaign.Id)
-	}
+func tearDown(t *testing.T, ctx *testContext) {
 	// Cleanup all users except the original admin
-	users, _ := models.GetUsers()
-	for _, user := range users {
-		if user.Id == 1 {
-			continue
-		}
-		err := models.DeleteUser(user.Id)
-		s.Nil(err)
-	}
+	// users, _ := models.GetUsers()
+	// for _, user := range users {
+	// 	if user.Id == 1 {
+	// 		continue
+	// 	}
+	// 	err := models.DeleteUser(user.Id)
+	// 	s.Nil(err)
+	// }
 }
 
-func (s *APISuite) SetupTest() {
+func createTestData(t *testing.T) {
 	// Add a group
 	group := models.Group{Name: "Test Group"}
 	group.Targets = []models.Target{
@@ -73,12 +65,12 @@ func (s *APISuite) SetupTest() {
 	models.PostGroup(&group)
 
 	// Add a template
-	t := models.Template{Name: "Test Template"}
-	t.Subject = "Test subject"
-	t.Text = "Text text"
-	t.HTML = "<html>Test</html>"
-	t.UserId = 1
-	models.PostTemplate(&t)
+	template := models.Template{Name: "Test Template"}
+	template.Subject = "Test subject"
+	template.Text = "Text text"
+	template.HTML = "<html>Test</html>"
+	template.UserId = 1
+	models.PostTemplate(&template)
 
 	// Add a landing page
 	p := models.Page{Name: "Test Page"}
@@ -97,7 +89,7 @@ func (s *APISuite) SetupTest() {
 	// Set the status such that no emails are attempted
 	c := models.Campaign{Name: "Test campaign"}
 	c.UserId = 1
-	c.Template = t
+	c.Template = template
 	c.Page = p
 	c.SMTP = smtp
 	c.Groups = []models.Group{group}
@@ -105,12 +97,13 @@ func (s *APISuite) SetupTest() {
 	c.UpdateStatus(models.CampaignEmailsSent)
 }
 
-func (s *APISuite) TestSiteImportBaseHref() {
+func TestSiteImportBaseHref(t *testing.T) {
+	ctx := setupTest(t)
 	h := "<html><head></head><body><img src=\"/test.png\"/></body></html>"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, h)
 	}))
-	hr := fmt.Sprintf("<html><head><base href=\"%s\"/></head><body><img src=\"/test.png\"/>\n</body></html>", ts.URL)
+	expected := fmt.Sprintf("<html><head><base href=\"%s\"/></head><body><img src=\"/test.png\"/>\n</body></html>", ts.URL)
 	defer ts.Close()
 	req := httptest.NewRequest(http.MethodPost, "/api/import/site",
 		bytes.NewBuffer([]byte(fmt.Sprintf(`
@@ -121,13 +114,13 @@ func (s *APISuite) TestSiteImportBaseHref() {
 		`, ts.URL))))
 	req.Header.Set("Content-Type", "application/json")
 	response := httptest.NewRecorder()
-	s.apiServer.ImportSite(response, req)
+	ctx.apiServer.ImportSite(response, req)
 	cs := cloneResponse{}
 	err := json.NewDecoder(response.Body).Decode(&cs)
-	s.Nil(err)
-	s.Equal(cs.HTML, hr)
-}
-
-func TestAPISuite(t *testing.T) {
-	suite.Run(t, new(APISuite))
+	if err != nil {
+		t.Fatalf("error decoding response: %v", err)
+	}
+	if cs.HTML != expected {
+		t.Fatalf("unexpected response received. expected %s got %s", expected, cs.HTML)
+	}
 }

--- a/controllers/api/user_test.go
+++ b/controllers/api/user_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"testing"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -13,9 +14,11 @@ import (
 	"github.com/gophish/gophish/models"
 )
 
-func (s *APISuite) createUnpriviledgedUser(slug string) *models.User {
+func createUnpriviledgedUser(t *testing.T, slug string) *models.User {
 	role, err := models.GetRoleBySlug(slug)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error getting role by slug: %v", err)
+	}
 	unauthorizedUser := &models.User{
 		Username: "foo",
 		Hash:     "bar",
@@ -24,56 +27,82 @@ func (s *APISuite) createUnpriviledgedUser(slug string) *models.User {
 		RoleID:   role.ID,
 	}
 	err = models.PutUser(unauthorizedUser)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error saving unpriviledged user: %v", err)
+	}
 	return unauthorizedUser
 }
 
-func (s *APISuite) TestGetUsers() {
+func TestGetUsers(t *testing.T) {
+	testCtx := setupTest(t)
 	r := httptest.NewRequest(http.MethodGet, "/api/users", nil)
-	r = ctx.Set(r, "user", s.admin)
+	r = ctx.Set(r, "user", testCtx.admin)
 	w := httptest.NewRecorder()
 
-	s.apiServer.Users(w, r)
-	s.Equal(w.Code, http.StatusOK)
+	testCtx.apiServer.Users(w, r)
+	expected := http.StatusOK
+	if w.Code != expected {
+		t.Fatalf("unexpected error code received. expected %d got %d", expected, w.Code)
+	}
 
 	got := []models.User{}
 	err := json.NewDecoder(w.Body).Decode(&got)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error decoding users data: %v", err)
+	}
 
 	// We only expect one user
-	s.Equal(1, len(got))
+	expectedUsers := 1
+	if len(got) != expectedUsers {
+		t.Fatalf("unexpected number of users returned. expected %d got %d", expectedUsers, len(got))
+	}
 	// And it should be the admin user
-	s.Equal(s.admin.Id, got[0].Id)
+	if testCtx.admin.Id != got[0].Id {
+		t.Fatalf("unexpected user received. expected %d got %d", testCtx.admin.Id, got[0].Id)
+	}
 }
 
-func (s *APISuite) TestCreateUser() {
+func TestCreateUser(t *testing.T) {
+	testCtx := setupTest(t)
 	payload := &userRequest{
 		Username: "foo",
 		Password: "bar",
 		Role:     models.RoleUser,
 	}
 	body, err := json.Marshal(payload)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error marshaling userRequest payload: %v", err)
+	}
 
 	r := httptest.NewRequest(http.MethodPost, "/api/users", bytes.NewBuffer(body))
 	r.Header.Set("Content-Type", "application/json")
-	r = ctx.Set(r, "user", s.admin)
+	r = ctx.Set(r, "user", testCtx.admin)
 	w := httptest.NewRecorder()
 
-	s.apiServer.Users(w, r)
-	s.Equal(w.Code, http.StatusOK)
+	testCtx.apiServer.Users(w, r)
+	expected := http.StatusOK
+	if w.Code != expected {
+		t.Fatalf("unexpected error code received. expected %d got %d", expected, w.Code)
+	}
 
 	got := &models.User{}
 	err = json.NewDecoder(w.Body).Decode(got)
-	s.Nil(err)
-	s.Equal(got.Username, payload.Username)
-	s.Equal(got.Role.Slug, payload.Role)
+	if err != nil {
+		t.Fatalf("error decoding user payload: %v", err)
+	}
+	if got.Username != payload.Username {
+		t.Fatalf("unexpected username received. expected %s got %s", payload.Username, got.Username)
+	}
+	if got.Role.Slug != payload.Role {
+		t.Fatalf("unexpected role received. expected %s got %s", payload.Role, got.Role.Slug)
+	}
 }
 
 // TestModifyUser tests that a user with the appropriate access is able to
 // modify their username and password.
-func (s *APISuite) TestModifyUser() {
-	unpriviledgedUser := s.createUnpriviledgedUser(models.RoleUser)
+func TestModifyUser(t *testing.T) {
+	testCtx := setupTest(t)
+	unpriviledgedUser := createUnpriviledgedUser(t, models.RoleUser)
 	newPassword := "new-password"
 	newUsername := "new-username"
 	payload := userRequest{
@@ -82,33 +111,48 @@ func (s *APISuite) TestModifyUser() {
 		Role:     unpriviledgedUser.Role.Slug,
 	}
 	body, err := json.Marshal(payload)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error marshaling userRequest payload: %v", err)
+	}
 	url := fmt.Sprintf("/api/users/%d", unpriviledgedUser.Id)
 	r := httptest.NewRequest(http.MethodPut, url, bytes.NewBuffer(body))
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", unpriviledgedUser.ApiKey))
 	w := httptest.NewRecorder()
 
-	s.apiServer.ServeHTTP(w, r)
+	testCtx.apiServer.ServeHTTP(w, r)
 	response := &models.User{}
 	err = json.NewDecoder(w.Body).Decode(response)
-	s.Nil(err)
-	s.Equal(w.Code, http.StatusOK)
-	s.Equal(response.Username, newUsername)
+	if err != nil {
+		t.Fatalf("error decoding user payload: %v", err)
+	}
+	expected := http.StatusOK
+	if w.Code != expected {
+		t.Fatalf("unexpected error code received. expected %d got %d", expected, w.Code)
+	}
+	if response.Username != newUsername {
+		t.Fatalf("unexpected username received. expected %s got %s", newUsername, response.Username)
+	}
 	got, err := models.GetUser(unpriviledgedUser.Id)
-	s.Nil(err)
-	s.Equal(response.Username, got.Username)
-	s.Equal(newUsername, got.Username)
+	if err != nil {
+		t.Fatalf("error getting unpriviledged user: %v", err)
+	}
+	if response.Username != got.Username {
+		t.Fatalf("unexpected username received. expected %s got %s", response.Username, got.Username)
+	}
 	err = bcrypt.CompareHashAndPassword([]byte(got.Hash), []byte(newPassword))
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("incorrect hash received for created user. expected %s got %s", []byte(newPassword), []byte(got.Hash))
+	}
 }
 
 // TestUnauthorizedListUsers ensures that users without the ModifySystem
 // permission are unable to list the users registered in Gophish.
-func (s *APISuite) TestUnauthorizedListUsers() {
+func TestUnauthorizedListUsers(t *testing.T) {
+	testCtx := setupTest(t)
 	// First, let's create a standard user which doesn't
 	// have ModifySystem permissions.
-	unauthorizedUser := s.createUnpriviledgedUser(models.RoleUser)
+	unauthorizedUser := createUnpriviledgedUser(t, models.RoleUser)
 	// We'll try to make a request to the various users API endpoints to
 	// ensure that they fail. Previously, we could hit the handlers directly
 	// but we need to go through the router for this test to ensure the
@@ -117,72 +161,99 @@ func (s *APISuite) TestUnauthorizedListUsers() {
 	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", unauthorizedUser.ApiKey))
 	w := httptest.NewRecorder()
 
-	s.apiServer.ServeHTTP(w, r)
-	s.Equal(w.Code, http.StatusForbidden)
+	testCtx.apiServer.ServeHTTP(w, r)
+	expected := http.StatusForbidden
+	if w.Code != expected {
+		t.Fatalf("unexpected error code received. expected %d got %d", expected, w.Code)
+	}
 }
 
 // TestUnauthorizedModifyUsers verifies that users without ModifySystem
 // permission (a "standard" user) can only get or modify their own information.
-func (s *APISuite) TestUnauthorizedGetUser() {
+func TestUnauthorizedGetUser(t *testing.T) {
+	testCtx := setupTest(t)
 	// First, we'll make sure that a user with the "user" role is unable to
 	// get the information of another user (in this case, the main admin).
-	unauthorizedUser := s.createUnpriviledgedUser(models.RoleUser)
-	url := fmt.Sprintf("/api/users/%d", s.admin.Id)
+	unauthorizedUser := createUnpriviledgedUser(t, models.RoleUser)
+	url := fmt.Sprintf("/api/users/%d", testCtx.admin.Id)
 	r := httptest.NewRequest(http.MethodGet, url, nil)
 	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", unauthorizedUser.ApiKey))
 	w := httptest.NewRecorder()
 
-	s.apiServer.ServeHTTP(w, r)
-	s.Equal(w.Code, http.StatusForbidden)
+	testCtx.apiServer.ServeHTTP(w, r)
+	expected := http.StatusForbidden
+	if w.Code != expected {
+		t.Fatalf("unexpected error code received. expected %d got %d", expected, w.Code)
+	}
 }
 
 // TestUnauthorizedModifyRole ensures that users without the ModifySystem
 // privilege are unable to modify their own role, preventing a potential
 // privilege escalation issue.
-func (s *APISuite) TestUnauthorizedSetRole() {
-	unauthorizedUser := s.createUnpriviledgedUser(models.RoleUser)
+func TestUnauthorizedSetRole(t *testing.T) {
+	testCtx := setupTest(t)
+	unauthorizedUser := createUnpriviledgedUser(t, models.RoleUser)
 	url := fmt.Sprintf("/api/users/%d", unauthorizedUser.Id)
 	payload := &userRequest{
 		Username: unauthorizedUser.Username,
 		Role:     models.RoleAdmin,
 	}
 	body, err := json.Marshal(payload)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error marshaling userRequest payload: %v", err)
+	}
 	r := httptest.NewRequest(http.MethodPut, url, bytes.NewBuffer(body))
 	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", unauthorizedUser.ApiKey))
 	w := httptest.NewRecorder()
 
-	s.apiServer.ServeHTTP(w, r)
-	s.Equal(w.Code, http.StatusBadRequest)
+	testCtx.apiServer.ServeHTTP(w, r)
+	expected := http.StatusBadRequest
+	if w.Code != expected {
+		t.Fatalf("unexpected error code received. expected %d got %d", expected, w.Code)
+	}
 	response := &models.Response{}
 	err = json.NewDecoder(w.Body).Decode(response)
-	s.Nil(err)
-	s.Equal(response.Message, ErrInsufficientPermission.Error())
+	if err != nil {
+		t.Fatalf("error decoding response payload: %v", err)
+	}
+	if response.Message != ErrInsufficientPermission.Error() {
+		t.Fatalf("incorrect error received when setting role. expected %s got %s", ErrInsufficientPermission.Error(), response.Message)
+	}
 }
 
 // TestModifyWithExistingUsername verifies that it's not possible to modify
 // an user's username to one which already exists.
-func (s *APISuite) TestModifyWithExistingUsername() {
-	unauthorizedUser := s.createUnpriviledgedUser(models.RoleUser)
+func TestModifyWithExistingUsername(t *testing.T) {
+	testCtx := setupTest(t)
+	unauthorizedUser := createUnpriviledgedUser(t, models.RoleUser)
 	payload := &userRequest{
-		Username: s.admin.Username,
+		Username: testCtx.admin.Username,
 		Role:     unauthorizedUser.Role.Slug,
 	}
 	body, err := json.Marshal(payload)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error marshaling userRequest payload: %v", err)
+	}
 	url := fmt.Sprintf("/api/users/%d", unauthorizedUser.Id)
 	r := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(body))
 	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", unauthorizedUser.ApiKey))
 	w := httptest.NewRecorder()
 
-	s.apiServer.ServeHTTP(w, r)
-	s.Equal(w.Code, http.StatusBadRequest)
-	expected := &models.Response{
+	testCtx.apiServer.ServeHTTP(w, r)
+	expected := http.StatusBadRequest
+	if w.Code != expected {
+		t.Fatalf("unexpected error code received. expected %d got %d", expected, w.Code)
+	}
+	expectedResponse := &models.Response{
 		Message: ErrUsernameTaken.Error(),
 		Success: false,
 	}
 	got := &models.Response{}
 	err = json.NewDecoder(w.Body).Decode(got)
-	s.Nil(err)
-	s.Equal(got.Message, expected.Message)
+	if err != nil {
+		t.Fatalf("error decoding response payload: %v", err)
+	}
+	if got.Message != expectedResponse.Message {
+		t.Fatalf("incorrect error received when setting role. expected %s got %s", expectedResponse.Message, got.Message)
+	}
 }

--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -1,62 +1,75 @@
 package controllers
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gophish/gophish/config"
 	"github.com/gophish/gophish/models"
-	"github.com/stretchr/testify/suite"
 )
 
-// ControllersSuite is a suite of tests to cover API related functions
-type ControllersSuite struct {
-	suite.Suite
+// testContext is the data required to test API related functions
+type testContext struct {
 	apiKey      string
 	config      *config.Config
 	adminServer *httptest.Server
 	phishServer *httptest.Server
+	origPath    string
 }
 
-func (s *ControllersSuite) SetupSuite() {
+func setupTest(t *testing.T) *testContext {
+	wd, _ := os.Getwd()
+	fmt.Println(wd)
 	conf := &config.Config{
 		DBName:         "sqlite3",
 		DBPath:         ":memory:",
 		MigrationsPath: "../db/db_sqlite3/migrations/",
 	}
+	abs, _ := filepath.Abs("../db/db_sqlite3/migrations/")
+	fmt.Printf("in controllers_test.go: %s\n", abs)
 	err := models.Setup(conf)
 	if err != nil {
-		s.T().Fatalf("Failed creating database: %v", err)
+		t.Fatalf("error setting up database: %v", err)
 	}
-	s.config = conf
-	s.Nil(err)
-	// Setup the admin server for use in testing
-	s.adminServer = httptest.NewUnstartedServer(NewAdminServer(s.config.AdminConf).server.Handler)
-	s.adminServer.Config.Addr = s.config.AdminConf.ListenURL
-	s.adminServer.Start()
+	ctx := &testContext{}
+	ctx.config = conf
+	ctx.adminServer = httptest.NewUnstartedServer(NewAdminServer(ctx.config.AdminConf).server.Handler)
+	ctx.adminServer.Config.Addr = ctx.config.AdminConf.ListenURL
+	ctx.adminServer.Start()
 	// Get the API key to use for these tests
 	u, err := models.GetUser(1)
-	s.Nil(err)
-	s.apiKey = u.ApiKey
+	if err != nil {
+		t.Fatalf("error getting first user from database: %v", err)
+	}
+	ctx.apiKey = u.ApiKey
 	// Start the phishing server
-	s.phishServer = httptest.NewUnstartedServer(NewPhishingServer(s.config.PhishConf).server.Handler)
-	s.phishServer.Config.Addr = s.config.PhishConf.ListenURL
-	s.phishServer.Start()
+	ctx.phishServer = httptest.NewUnstartedServer(NewPhishingServer(ctx.config.PhishConf).server.Handler)
+	ctx.phishServer.Config.Addr = ctx.config.PhishConf.ListenURL
+	ctx.phishServer.Start()
 	// Move our cwd up to the project root for help with resolving
 	// static assets
+	origPath, _ := os.Getwd()
+	ctx.origPath = origPath
 	err = os.Chdir("../")
-	s.Nil(err)
-}
-
-func (s *ControllersSuite) TearDownTest() {
-	campaigns, _ := models.GetCampaigns(1)
-	for _, campaign := range campaigns {
-		models.DeleteCampaign(campaign.Id)
+	if err != nil {
+		t.Fatalf("error changing directories to setup asset discovery: %v", err)
 	}
+	createTestData(t)
+	return ctx
 }
 
-func (s *ControllersSuite) SetupTest() {
+func tearDown(t *testing.T, ctx *testContext) {
+	// Tear down the admin and phishing servers
+	ctx.adminServer.Close()
+	ctx.phishServer.Close()
+	// Reset the path for the next test
+	os.Chdir(ctx.origPath)
+}
+
+func createTestData(t *testing.T) {
 	// Add a group
 	group := models.Group{Name: "Test Group"}
 	group.Targets = []models.Target{
@@ -67,12 +80,12 @@ func (s *ControllersSuite) SetupTest() {
 	models.PostGroup(&group)
 
 	// Add a template
-	t := models.Template{Name: "Test Template"}
-	t.Subject = "Test subject"
-	t.Text = "Text text"
-	t.HTML = "<html>Test</html>"
-	t.UserId = 1
-	models.PostTemplate(&t)
+	template := models.Template{Name: "Test Template"}
+	template.Subject = "Test subject"
+	template.Text = "Text text"
+	template.HTML = "<html>Test</html>"
+	template.UserId = 1
+	models.PostTemplate(&template)
 
 	// Add a landing page
 	p := models.Page{Name: "Test Page"}
@@ -91,20 +104,10 @@ func (s *ControllersSuite) SetupTest() {
 	// Set the status such that no emails are attempted
 	c := models.Campaign{Name: "Test campaign"}
 	c.UserId = 1
-	c.Template = t
+	c.Template = template
 	c.Page = p
 	c.SMTP = smtp
 	c.Groups = []models.Group{group}
 	models.PostCampaign(&c, c.UserId)
 	c.UpdateStatus(models.CampaignEmailsSent)
-}
-
-func (s *ControllersSuite) TearDownSuite() {
-	// Tear down the admin and phishing servers
-	s.adminServer.Close()
-	s.phishServer.Close()
-}
-
-func TestControllerSuite(t *testing.T) {
-	suite.Run(t, new(ControllersSuite))
 }

--- a/controllers/phish_test.go
+++ b/controllers/phish_test.go
@@ -5,22 +5,25 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
+	"reflect"
+	"testing"
 
 	"github.com/gophish/gophish/config"
 	"github.com/gophish/gophish/models"
 )
 
-func (s *ControllersSuite) getFirstCampaign() models.Campaign {
+func getFirstCampaign(t *testing.T) models.Campaign {
 	campaigns, err := models.GetCampaigns(1)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error getting first campaign from database: %v", err)
+	}
 	return campaigns[0]
 }
 
-func (s *ControllersSuite) getFirstEmailRequest() models.EmailRequest {
-	campaign := s.getFirstCampaign()
+func getFirstEmailRequest(t *testing.T) models.EmailRequest {
+	campaign := getFirstCampaign(t)
 	req := models.EmailRequest{
 		TemplateId:    campaign.TemplateId,
 		Template:      campaign.Template,
@@ -33,205 +36,334 @@ func (s *ControllersSuite) getFirstEmailRequest() models.EmailRequest {
 		FromAddress:   campaign.SMTP.FromAddress,
 	}
 	err := models.PostEmailRequest(&req)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error creating email request: %v", err)
+	}
 	return req
 }
 
-func (s *ControllersSuite) openEmail(rid string) {
-	resp, err := http.Get(fmt.Sprintf("%s/track?%s=%s", s.phishServer.URL, models.RecipientParameter, rid))
-	s.Nil(err)
+func openEmail(t *testing.T, ctx *testContext, rid string) {
+	resp, err := http.Get(fmt.Sprintf("%s/track?%s=%s", ctx.phishServer.URL, models.RecipientParameter, rid))
+	if err != nil {
+		t.Fatalf("error requesting /track endpoint: %v", err)
+	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	s.Nil(err)
+	got, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("error reading response body from /track endpoint: %v", err)
+	}
 	expected, err := ioutil.ReadFile("static/images/pixel.png")
-	s.Nil(err)
-	s.Equal(bytes.Compare(body, expected), 0)
+	if err != nil {
+		t.Fatalf("error reading local transparent pixel: %v", err)
+	}
+	if !bytes.Equal(got, expected) {
+		t.Fatalf("unexpected tracking pixel data received. expected %#v got %#v", expected, got)
+	}
 }
 
-func (s *ControllersSuite) reportedEmail(rid string) {
-	resp, err := http.Get(fmt.Sprintf("%s/report?%s=%s", s.phishServer.URL, models.RecipientParameter, rid))
-	s.Nil(err)
-	s.Equal(resp.StatusCode, http.StatusNoContent)
-}
-
-func (s *ControllersSuite) reportEmail404(rid string) {
-	resp, err := http.Get(fmt.Sprintf("%s/report?%s=%s", s.phishServer.URL, models.RecipientParameter, rid))
-	s.Nil(err)
-	s.Equal(resp.StatusCode, http.StatusNotFound)
-}
-
-func (s *ControllersSuite) openEmail404(rid string) {
-	resp, err := http.Get(fmt.Sprintf("%s/track?%s=%s", s.phishServer.URL, models.RecipientParameter, rid))
-	s.Nil(err)
+func openEmail404(t *testing.T, ctx *testContext, rid string) {
+	resp, err := http.Get(fmt.Sprintf("%s/track?%s=%s", ctx.phishServer.URL, models.RecipientParameter, rid))
+	if err != nil {
+		t.Fatalf("error requesting /track endpoint: %v", err)
+	}
 	defer resp.Body.Close()
-	s.Nil(err)
-	s.Equal(resp.StatusCode, http.StatusNotFound)
+	got := resp.StatusCode
+	expected := http.StatusNotFound
+	if got != expected {
+		t.Fatalf("invalid status code received for /track endpoint. expected %d got %d", expected, got)
+	}
 }
 
-func (s *ControllersSuite) clickLink(rid string, expectedHTML string) {
-	resp, err := http.Get(fmt.Sprintf("%s/?%s=%s", s.phishServer.URL, models.RecipientParameter, rid))
-	s.Nil(err)
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	s.Nil(err)
-	log.Printf("%s\n\n\n", body)
-	s.Equal(bytes.Compare(body, []byte(expectedHTML)), 0)
+func reportedEmail(t *testing.T, ctx *testContext, rid string) {
+	resp, err := http.Get(fmt.Sprintf("%s/report?%s=%s", ctx.phishServer.URL, models.RecipientParameter, rid))
+	if err != nil {
+		t.Fatalf("error requesting /report endpoint: %v", err)
+	}
+	got := resp.StatusCode
+	expected := http.StatusNoContent
+	if got != expected {
+		t.Fatalf("invalid status code received for /report endpoint. expected %d got %d", expected, got)
+	}
 }
 
-func (s *ControllersSuite) clickLink404(rid string) {
-	resp, err := http.Get(fmt.Sprintf("%s/?%s=%s", s.phishServer.URL, models.RecipientParameter, rid))
-	s.Nil(err)
-	defer resp.Body.Close()
-	s.Nil(err)
-	s.Equal(resp.StatusCode, http.StatusNotFound)
+func reportEmail404(t *testing.T, ctx *testContext, rid string) {
+	resp, err := http.Get(fmt.Sprintf("%s/report?%s=%s", ctx.phishServer.URL, models.RecipientParameter, rid))
+	if err != nil {
+		t.Fatalf("error requesting /report endpoint: %v", err)
+	}
+	got := resp.StatusCode
+	expected := http.StatusNotFound
+	if got != expected {
+		t.Fatalf("invalid status code received for /report endpoint. expected %d got %d", expected, got)
+	}
 }
 
-func (s *ControllersSuite) transparencyRequest(r models.Result, rid, path string) {
-	resp, err := http.Get(fmt.Sprintf("%s%s?%s=%s", s.phishServer.URL, path, models.RecipientParameter, rid))
-	s.Nil(err)
+func clickLink(t *testing.T, ctx *testContext, rid string, expectedHTML string) {
+	resp, err := http.Get(fmt.Sprintf("%s/?%s=%s", ctx.phishServer.URL, models.RecipientParameter, rid))
+	if err != nil {
+		t.Fatalf("error requesting / endpoint: %v", err)
+	}
 	defer resp.Body.Close()
-	s.Equal(resp.StatusCode, http.StatusOK)
+	got, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("error reading payload from / endpoint response: %v", err)
+	}
+	if !bytes.Equal(got, []byte(expectedHTML)) {
+		t.Fatalf("invalid response received from / endpoint. expected %s got %s", got, expectedHTML)
+	}
+}
+
+func clickLink404(t *testing.T, ctx *testContext, rid string) {
+	resp, err := http.Get(fmt.Sprintf("%s/?%s=%s", ctx.phishServer.URL, models.RecipientParameter, rid))
+	if err != nil {
+		t.Fatalf("error requesting / endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+	got := resp.StatusCode
+	expected := http.StatusNotFound
+	if got != expected {
+		t.Fatalf("invalid status code received for / endpoint. expected %d got %d", expected, got)
+	}
+}
+
+func transparencyRequest(t *testing.T, ctx *testContext, r models.Result, rid, path string) {
+	resp, err := http.Get(fmt.Sprintf("%s%s?%s=%s", ctx.phishServer.URL, path, models.RecipientParameter, rid))
+	if err != nil {
+		t.Fatalf("error requesting %s endpoint: %v", path, err)
+	}
+	defer resp.Body.Close()
+	got := resp.StatusCode
+	expected := http.StatusOK
+	if got != expected {
+		t.Fatalf("invalid status code received for / endpoint. expected %d got %d", expected, got)
+	}
 	tr := &TransparencyResponse{}
 	err = json.NewDecoder(resp.Body).Decode(tr)
-	s.Nil(err)
-	s.Equal(tr.ContactAddress, s.config.ContactAddress)
-	s.Equal(tr.SendDate, r.SendDate)
-	s.Equal(tr.Server, config.ServerName)
+	if err != nil {
+		t.Fatalf("error unmarshaling transparency request: %v", err)
+	}
+	expectedResponse := &TransparencyResponse{
+		ContactAddress: ctx.config.ContactAddress,
+		SendDate:       r.SendDate,
+		Server:         config.ServerName,
+	}
+	if !reflect.DeepEqual(tr, expectedResponse) {
+		t.Fatalf("unexpected transparency response received. expected %v got %v", expectedResponse, tr)
+	}
 }
 
-func (s *ControllersSuite) TestOpenedPhishingEmail() {
-	campaign := s.getFirstCampaign()
+func TestOpenedPhishingEmail(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	campaign := getFirstCampaign(t)
 	result := campaign.Results[0]
-	s.Equal(result.Status, models.StatusSending)
+	if result.Status != models.StatusSending {
+		t.Fatalf("unexpected result status received. expected %s got %s", models.StatusSending, result.Status)
+	}
 
-	s.openEmail(result.RId)
+	openEmail(t, ctx, result.RId)
 
-	campaign = s.getFirstCampaign()
+	campaign = getFirstCampaign(t)
 	result = campaign.Results[0]
 	lastEvent := campaign.Events[len(campaign.Events)-1]
-	s.Equal(result.Status, models.EventOpened)
-	s.Equal(lastEvent.Message, models.EventOpened)
-	s.Equal(result.ModifiedDate, lastEvent.Time)
+	if result.Status != models.EventOpened {
+		t.Fatalf("unexpected result status received. expected %s got %s", models.EventOpened, result.Status)
+	}
+	if lastEvent.Message != models.EventOpened {
+		t.Fatalf("unexpected event status received. expected %s got %s", lastEvent.Message, models.EventOpened)
+	}
+	if result.ModifiedDate != lastEvent.Time {
+		t.Fatalf("unexpected result modified date received. expected %s got %s", lastEvent.Time, result.ModifiedDate)
+	}
 }
 
-func (s *ControllersSuite) TestReportedPhishingEmail() {
-	campaign := s.getFirstCampaign()
+func TestReportedPhishingEmail(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	campaign := getFirstCampaign(t)
 	result := campaign.Results[0]
-	s.Equal(result.Status, models.StatusSending)
+	if result.Status != models.StatusSending {
+		t.Fatalf("unexpected result status received. expected %s got %s", models.StatusSending, result.Status)
+	}
 
-	s.reportedEmail(result.RId)
+	reportedEmail(t, ctx, result.RId)
 
-	campaign = s.getFirstCampaign()
+	campaign = getFirstCampaign(t)
 	result = campaign.Results[0]
 	lastEvent := campaign.Events[len(campaign.Events)-1]
-	s.Equal(result.Reported, true)
-	s.Equal(lastEvent.Message, models.EventReported)
-	s.Equal(result.ModifiedDate, lastEvent.Time)
+
+	if result.Reported != true {
+		t.Fatalf("unexpected result report status received. expected %v got %v", true, result.Reported)
+	}
+	if lastEvent.Message != models.EventReported {
+		t.Fatalf("unexpected event status received. expected %s got %s", lastEvent.Message, models.EventReported)
+	}
+	if result.ModifiedDate != lastEvent.Time {
+		t.Fatalf("unexpected result modified date received. expected %s got %s", lastEvent.Time, result.ModifiedDate)
+	}
 }
 
-func (s *ControllersSuite) TestClickedPhishingLinkAfterOpen() {
-	campaign := s.getFirstCampaign()
+func TestClickedPhishingLinkAfterOpen(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	campaign := getFirstCampaign(t)
 	result := campaign.Results[0]
-	s.Equal(result.Status, models.StatusSending)
+	if result.Status != models.StatusSending {
+		t.Fatalf("unexpected result status received. expected %s got %s", models.StatusSending, result.Status)
+	}
 
-	s.openEmail(result.RId)
-	s.clickLink(result.RId, campaign.Page.HTML)
+	openEmail(t, ctx, result.RId)
+	clickLink(t, ctx, result.RId, campaign.Page.HTML)
 
-	campaign = s.getFirstCampaign()
+	campaign = getFirstCampaign(t)
 	result = campaign.Results[0]
 	lastEvent := campaign.Events[len(campaign.Events)-1]
-	s.Equal(result.Status, models.EventClicked)
-	s.Equal(lastEvent.Message, models.EventClicked)
-	s.Equal(result.ModifiedDate, lastEvent.Time)
+	if result.Status != models.EventClicked {
+		t.Fatalf("unexpected result status received. expected %s got %s", models.EventClicked, result.Status)
+	}
+	if lastEvent.Message != models.EventClicked {
+		t.Fatalf("unexpected event status received. expected %s got %s", lastEvent.Message, models.EventClicked)
+	}
+	if result.ModifiedDate != lastEvent.Time {
+		t.Fatalf("unexpected result modified date received. expected %s got %s", lastEvent.Time, result.ModifiedDate)
+	}
 }
 
-func (s *ControllersSuite) TestNoRecipientID() {
-	resp, err := http.Get(fmt.Sprintf("%s/track", s.phishServer.URL))
-	s.Nil(err)
-	s.Equal(resp.StatusCode, http.StatusNotFound)
+func TestNoRecipientID(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	resp, err := http.Get(fmt.Sprintf("%s/track", ctx.phishServer.URL))
+	if err != nil {
+		t.Fatalf("error requesting /track endpoint: %v", err)
+	}
+	got := resp.StatusCode
+	expected := http.StatusNotFound
+	if got != expected {
+		t.Fatalf("invalid status code received for /track endpoint. expected %d got %d", expected, got)
+	}
 
-	resp, err = http.Get(s.phishServer.URL)
-	s.Nil(err)
-	s.Equal(resp.StatusCode, http.StatusNotFound)
+	resp, err = http.Get(ctx.phishServer.URL)
+	if err != nil {
+		t.Fatalf("error requesting /track endpoint: %v", err)
+	}
+	got = resp.StatusCode
+	if got != expected {
+		t.Fatalf("invalid status code received for / endpoint. expected %d got %d", expected, got)
+	}
 }
 
-func (s *ControllersSuite) TestInvalidRecipientID() {
+func TestInvalidRecipientID(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
 	rid := "XXXXXXXXXX"
-	s.openEmail404(rid)
-	s.clickLink404(rid)
-	s.reportEmail404(rid)
+	openEmail404(t, ctx, rid)
+	clickLink404(t, ctx, rid)
+	reportEmail404(t, ctx, rid)
 }
 
-func (s *ControllersSuite) TestCompletedCampaignClick() {
-	campaign := s.getFirstCampaign()
+func TestCompletedCampaignClick(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	campaign := getFirstCampaign(t)
 	result := campaign.Results[0]
-	s.Equal(result.Status, models.StatusSending)
-	s.openEmail(result.RId)
+	if result.Status != models.StatusSending {
+		t.Fatalf("unexpected result status received. expected %s got %s", models.StatusSending, result.Status)
+	}
 
-	campaign = s.getFirstCampaign()
+	openEmail(t, ctx, result.RId)
+
+	campaign = getFirstCampaign(t)
 	result = campaign.Results[0]
-	s.Equal(result.Status, models.EventOpened)
+	if result.Status != models.EventOpened {
+		t.Fatalf("unexpected result status received. expected %s got %s", models.EventOpened, result.Status)
+	}
 
 	models.CompleteCampaign(campaign.Id, 1)
-	s.openEmail404(result.RId)
-	s.clickLink404(result.RId)
+	openEmail404(t, ctx, result.RId)
+	clickLink404(t, ctx, result.RId)
 
-	campaign = s.getFirstCampaign()
+	campaign = getFirstCampaign(t)
 	result = campaign.Results[0]
-	s.Equal(result.Status, models.EventOpened)
+	if result.Status != models.EventOpened {
+		t.Fatalf("unexpected result status received. expected %s got %s", models.EventOpened, result.Status)
+	}
 }
 
-func (s *ControllersSuite) TestRobotsHandler() {
-	expected := []byte("User-agent: *\nDisallow: /\n")
-	resp, err := http.Get(fmt.Sprintf("%s/robots.txt", s.phishServer.URL))
-	s.Nil(err)
-	s.Equal(resp.StatusCode, http.StatusOK)
+func TestRobotsHandler(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	resp, err := http.Get(fmt.Sprintf("%s/robots.txt", ctx.phishServer.URL))
+	if err != nil {
+		t.Fatalf("error requesting /robots.txt endpoint: %v", err)
+	}
 	defer resp.Body.Close()
+	got := resp.StatusCode
+	expectedStatus := http.StatusOK
+	if got != expectedStatus {
+		t.Fatalf("invalid status code received for /track endpoint. expected %d got %d", expectedStatus, got)
+	}
+	expected := []byte("User-agent: *\nDisallow: /\n")
 	body, err := ioutil.ReadAll(resp.Body)
-	s.Nil(err)
-	s.Equal(bytes.Compare(body, expected), 0)
+	if err != nil {
+		t.Fatalf("error reading response body from /robots.txt endpoint: %v", err)
+	}
+	if !bytes.Equal(body, expected) {
+		t.Fatalf("invalid robots.txt response received. expected %s got %s", expected, body)
+	}
 }
 
-func (s *ControllersSuite) TestInvalidPreviewID() {
+func TestInvalidPreviewID(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
 	bogusRId := fmt.Sprintf("%sbogus", models.PreviewPrefix)
-	s.openEmail404(bogusRId)
-	s.clickLink404(bogusRId)
-	s.reportEmail404(bogusRId)
+	openEmail404(t, ctx, bogusRId)
+	clickLink404(t, ctx, bogusRId)
+	reportEmail404(t, ctx, bogusRId)
 }
 
-func (s *ControllersSuite) TestPreviewTrack() {
-	req := s.getFirstEmailRequest()
-	s.openEmail(req.RId)
+func TestPreviewTrack(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	req := getFirstEmailRequest(t)
+	openEmail(t, ctx, req.RId)
 }
 
-func (s *ControllersSuite) TestPreviewClick() {
-	req := s.getFirstEmailRequest()
-	s.clickLink(req.RId, req.Page.HTML)
+func TestPreviewClick(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	req := getFirstEmailRequest(t)
+	clickLink(t, ctx, req.RId, req.Page.HTML)
 }
 
-func (s *ControllersSuite) TestInvalidTransparencyRequest() {
+func TestInvalidTransparencyRequest(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
 	bogusRId := fmt.Sprintf("bogus%s", TransparencySuffix)
-	s.openEmail404(bogusRId)
-	s.clickLink404(bogusRId)
-	s.reportEmail404(bogusRId)
+	openEmail404(t, ctx, bogusRId)
+	clickLink404(t, ctx, bogusRId)
+	reportEmail404(t, ctx, bogusRId)
 }
 
-func (s *ControllersSuite) TestTransparencyRequest() {
-	campaign := s.getFirstCampaign()
+func TestTransparencyRequest(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	campaign := getFirstCampaign(t)
 	result := campaign.Results[0]
 	rid := fmt.Sprintf("%s%s", result.RId, TransparencySuffix)
-	s.transparencyRequest(result, rid, "/")
-	s.transparencyRequest(result, rid, "/track")
-	s.transparencyRequest(result, rid, "/report")
+	transparencyRequest(t, ctx, result, rid, "/")
+	transparencyRequest(t, ctx, result, rid, "/track")
+	transparencyRequest(t, ctx, result, rid, "/report")
 
 	// And check with the URL encoded version of a +
 	rid = fmt.Sprintf("%s%s", result.RId, "%2b")
-	s.transparencyRequest(result, rid, "/")
-	s.transparencyRequest(result, rid, "/track")
-	s.transparencyRequest(result, rid, "/report")
+	transparencyRequest(t, ctx, result, rid, "/")
+	transparencyRequest(t, ctx, result, rid, "/track")
+	transparencyRequest(t, ctx, result, rid, "/report")
 }
 
-func (s *ControllersSuite) TestRedirectTemplating() {
+func TestRedirectTemplating(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
 	p := models.Page{
 		Name:        "Redirect Page",
 		HTML:        "<html>Test</html>",
@@ -239,7 +371,9 @@ func (s *ControllersSuite) TestRedirectTemplating() {
 		RedirectURL: "http://example.com/{{.RId}}",
 	}
 	err := models.PostPage(&p)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error posting new page: %v", err)
+	}
 	smtp, _ := models.GetSMTP(1, 1)
 	template, _ := models.GetTemplate(1, 1)
 	group, _ := models.GetGroup(1, 1)
@@ -251,7 +385,9 @@ func (s *ControllersSuite) TestRedirectTemplating() {
 	campaign.SMTP = smtp
 	campaign.Groups = []models.Group{group}
 	err = models.PostCampaign(&campaign, campaign.UserId)
-	s.Nil(err)
+	if err != nil {
+		t.Fatalf("error creating campaign: %v", err)
+	}
 
 	client := http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -259,12 +395,22 @@ func (s *ControllersSuite) TestRedirectTemplating() {
 		},
 	}
 	result := campaign.Results[0]
-	resp, err := client.PostForm(fmt.Sprintf("%s/?%s=%s", s.phishServer.URL, models.RecipientParameter, result.RId), url.Values{"username": {"test"}, "password": {"test"}})
-	s.Nil(err)
+	resp, err := client.PostForm(fmt.Sprintf("%s/?%s=%s", ctx.phishServer.URL, models.RecipientParameter, result.RId), url.Values{"username": {"test"}, "password": {"test"}})
+	if err != nil {
+		t.Fatalf("error requesting / endpoint: %v", err)
+	}
 	defer resp.Body.Close()
-	s.Equal(http.StatusFound, resp.StatusCode)
+	got := resp.StatusCode
+	expectedStatus := http.StatusFound
+	if got != expectedStatus {
+		t.Fatalf("invalid status code received for /track endpoint. expected %d got %d", expectedStatus, got)
+	}
 	expectedURL := fmt.Sprintf("http://example.com/%s", result.RId)
-	got, err := resp.Location()
-	s.Nil(err)
-	s.Equal(expectedURL, got.String())
+	gotURL, err := resp.Location()
+	if err != nil {
+		t.Fatalf("error getting Location header from response: %v", err)
+	}
+	if gotURL.String() != expectedURL {
+		t.Fatalf("invalid redirect received. expected %s got %s", expectedURL, gotURL)
+	}
 }

--- a/controllers/route_test.go
+++ b/controllers/route_test.go
@@ -5,106 +5,115 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"testing"
 
 	"github.com/PuerkitoBio/goquery"
 )
 
-func (s *ControllersSuite) TestLoginCSRF() {
-	resp, err := http.PostForm(fmt.Sprintf("%s/login", s.adminServer.URL),
+func attemptLogin(t *testing.T, ctx *testContext, client *http.Client, username, password, optionalPath string) *http.Response {
+	resp, err := http.Get(fmt.Sprintf("%s/login", ctx.adminServer.URL))
+	if err != nil {
+		t.Fatalf("error requesting the /login endpoint: %v", err)
+	}
+	got := resp.StatusCode
+	expected := http.StatusOK
+	if got != expected {
+		t.Fatalf("invalid status code received. expected %d got %d", expected, got)
+	}
+
+	doc, err := goquery.NewDocumentFromResponse(resp)
+	if err != nil {
+		t.Fatalf("error parsing /login response body")
+	}
+	elem := doc.Find("input[name='csrf_token']").First()
+	token, ok := elem.Attr("value")
+	if !ok {
+		t.Fatal("unable to find csrf_token value in login response")
+	}
+	if client == nil {
+		client = &http.Client{}
+	}
+
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/login%s", ctx.adminServer.URL, optionalPath), strings.NewReader(url.Values{
+		"username":   {username},
+		"password":   {password},
+		"csrf_token": {token},
+	}.Encode()))
+	if err != nil {
+		t.Fatalf("error creating new /login request: %v", err)
+	}
+
+	req.Header.Set("Cookie", resp.Header.Get("Set-Cookie"))
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("error requesting the /login endpoint: %v", err)
+	}
+	return resp
+}
+
+func TestLoginCSRF(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	resp, err := http.PostForm(fmt.Sprintf("%s/login", ctx.adminServer.URL),
 		url.Values{
 			"username": {"admin"},
 			"password": {"gophish"},
 		})
 
-	s.Equal(resp.StatusCode, http.StatusForbidden)
-	fmt.Println(err)
+	if err != nil {
+		t.Fatalf("error requesting the /login endpoint: %v", err)
+	}
+
+	got := resp.StatusCode
+	expected := http.StatusForbidden
+	if got != expected {
+		t.Fatalf("invalid status code received. expected %d got %d", expected, got)
+	}
 }
 
-func (s *ControllersSuite) TestInvalidCredentials() {
-	resp, err := http.Get(fmt.Sprintf("%s/login", s.adminServer.URL))
-	s.Equal(err, nil)
-	s.Equal(resp.StatusCode, http.StatusOK)
-
-	doc, err := goquery.NewDocumentFromResponse(resp)
-	s.Equal(err, nil)
-	elem := doc.Find("input[name='csrf_token']").First()
-	token, ok := elem.Attr("value")
-	s.Equal(ok, true)
-
-	client := &http.Client{}
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/login", s.adminServer.URL), strings.NewReader(url.Values{
-		"username":   {"admin"},
-		"password":   {"invalid"},
-		"csrf_token": {token},
-	}.Encode()))
-	s.Equal(err, nil)
-
-	req.Header.Set("Cookie", resp.Header.Get("Set-Cookie"))
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err = client.Do(req)
-	s.Equal(err, nil)
-	s.Equal(resp.StatusCode, http.StatusUnauthorized)
+func TestInvalidCredentials(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	resp := attemptLogin(t, ctx, nil, "admin", "bogus", "")
+	got := resp.StatusCode
+	expected := http.StatusUnauthorized
+	if got != expected {
+		t.Fatalf("invalid status code received. expected %d got %d", expected, got)
+	}
 }
 
-func (s *ControllersSuite) TestSuccessfulLogin() {
-	resp, err := http.Get(fmt.Sprintf("%s/login", s.adminServer.URL))
-	s.Equal(err, nil)
-	s.Equal(resp.StatusCode, http.StatusOK)
-
-	doc, err := goquery.NewDocumentFromResponse(resp)
-	s.Equal(err, nil)
-	elem := doc.Find("input[name='csrf_token']").First()
-	token, ok := elem.Attr("value")
-	s.Equal(ok, true)
-
-	client := &http.Client{}
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/login", s.adminServer.URL), strings.NewReader(url.Values{
-		"username":   {"admin"},
-		"password":   {"gophish"},
-		"csrf_token": {token},
-	}.Encode()))
-	s.Equal(err, nil)
-
-	req.Header.Set("Cookie", resp.Header.Get("Set-Cookie"))
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err = client.Do(req)
-	s.Equal(err, nil)
-	s.Equal(resp.StatusCode, http.StatusOK)
+func TestSuccessfulLogin(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
+	resp := attemptLogin(t, ctx, nil, "admin", "gophish", "")
+	got := resp.StatusCode
+	expected := http.StatusOK
+	if got != expected {
+		t.Fatalf("invalid status code received. expected %d got %d", expected, got)
+	}
 }
 
-func (s *ControllersSuite) TestSuccessfulRedirect() {
+func TestSuccessfulRedirect(t *testing.T) {
+	ctx := setupTest(t)
+	defer tearDown(t, ctx)
 	next := "/campaigns"
-	resp, err := http.Get(fmt.Sprintf("%s/login", s.adminServer.URL))
-	s.Equal(err, nil)
-	s.Equal(resp.StatusCode, http.StatusOK)
-
-	doc, err := goquery.NewDocumentFromResponse(resp)
-	s.Equal(err, nil)
-	elem := doc.Find("input[name='csrf_token']").First()
-	token, ok := elem.Attr("value")
-	s.Equal(ok, true)
-
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
-		},
+		}}
+	resp := attemptLogin(t, ctx, client, "admin", "gophish", fmt.Sprintf("?next=%s", next))
+	got := resp.StatusCode
+	expected := http.StatusFound
+	if got != expected {
+		t.Fatalf("invalid status code received. expected %d got %d", expected, got)
 	}
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/login?next=%s", s.adminServer.URL, next), strings.NewReader(url.Values{
-		"username":   {"admin"},
-		"password":   {"gophish"},
-		"csrf_token": {token},
-	}.Encode()))
-	s.Equal(err, nil)
-
-	req.Header.Set("Cookie", resp.Header.Get("Set-Cookie"))
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err = client.Do(req)
-	s.Equal(err, nil)
-	s.Equal(resp.StatusCode, http.StatusFound)
 	url, err := resp.Location()
-	s.Equal(err, nil)
-	s.Equal(url.Path, next)
+	if err != nil {
+		t.Fatalf("error parsing response Location header: %v", err)
+	}
+	if url.Path != next {
+		t.Fatalf("unexpected Location header received. expected %s got %s", next, url.Path)
+	}
 }

--- a/models/models.go
+++ b/models/models.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"path/filepath"
 	"time"
 
 	"bitbucket.org/liamstask/goose/lib/goose"
@@ -93,6 +94,8 @@ func Setup(c *config.Config) error {
 		Env:           "production",
 		Driver:        chooseDBDriver(conf.DBName, conf.DBPath),
 	}
+	abs, _ := filepath.Abs(migrateConf.MigrationsDir)
+	fmt.Println(abs)
 	// Get the latest possible migration
 	latest, err := goose.GetMostRecentDBVersion(migrateConf.MigrationsDir)
 	if err != nil {


### PR DESCRIPTION
This PR removes the `github.com/stretchr/testify` dependency. This package recently got updates that broke our tests.

While I'm going to be moving to use Go modules ASAP, I've also wanted to consolidate tests to just use the standard `testing` package so this seemed like a good opportunity to start that move.