### PR TITLE
Added ability to allow admin to 'su' to other accounts

### DIFF
--- a/controllers/route.go
+++ b/controllers/route.go
@@ -4,7 +4,6 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
-	"fmt"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -180,8 +179,6 @@ func newTemplateParams(r *http.Request) templateParams {
 // Base handles the default path and template execution
 func (as *AdminServer) Base(w http.ResponseWriter, r *http.Request) {
 	params := newTemplateParams(r)
-
-	fmt.Println(params)
 	params.Title = "Dashboard"
 	getTemplate(w, "dashboard").ExecuteTemplate(w, "base", params)
 }

--- a/controllers/route.go
+++ b/controllers/route.go
@@ -4,6 +4,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
+	"fmt"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -130,7 +131,7 @@ func (as *AdminServer) registerRoutes() {
 	router.HandleFunc("/settings", mid.Use(as.Settings, mid.RequireLogin))
 	router.HandleFunc("/users", mid.Use(as.UserManagement, mid.RequirePermission(models.PermissionModifySystem), mid.RequireLogin))
 	router.HandleFunc("/webhooks", mid.Use(as.Webhooks, mid.RequirePermission(models.PermissionModifySystem), mid.RequireLogin))
-	router.HandleFunc("/superlogin", mid.Use(as.SuperLogin, mid.RequirePermission(models.PermissionModifySystem), mid.RequireLogin))
+	router.HandleFunc("/impersonate", mid.Use(as.Impersonate, mid.RequirePermission(models.PermissionModifySystem), mid.RequireLogin))
 	// Create the API routes
 	api := api.NewServer(api.WithWorker(as.worker))
 	router.PathPrefix("/api/").Handler(api)
@@ -179,6 +180,8 @@ func newTemplateParams(r *http.Request) templateParams {
 // Base handles the default path and template execution
 func (as *AdminServer) Base(w http.ResponseWriter, r *http.Request) {
 	params := newTemplateParams(r)
+
+	fmt.Println(params)
 	params.Title = "Dashboard"
 	getTemplate(w, "dashboard").ExecuteTemplate(w, "base", params)
 }
@@ -266,21 +269,22 @@ func (as *AdminServer) Webhooks(w http.ResponseWriter, r *http.Request) {
 	getTemplate(w, "webhooks").ExecuteTemplate(w, "base", params)
 }
 
-// SuperLogin allows an admin to login to a user account without needing the password
-func (as *AdminServer) SuperLogin(w http.ResponseWriter, r *http.Request) {
+// Impersonate allows an admin to login to a user account without needing the password
+func (as *AdminServer) Impersonate(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method == "POST" {
 		username := r.FormValue("username")
 		u, err := models.GetUserByUsername(username)
 		if err != nil {
 			log.Error(err)
-		} else {
-			session := ctx.Get(r, "session").(*sessions.Session)
-			session.Values["id"] = u.Id
-			session.Save(r, w)
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
 		}
+		session := ctx.Get(r, "session").(*sessions.Session)
+		session.Values["id"] = u.Id
+		session.Save(r, w)
 	}
-	http.Redirect(w, r, "/settings", 302)
+	http.Redirect(w, r, "/", 302)
 }
 
 // Login handles the authentication flow for a user. If credentials are valid,

--- a/static/js/src/app/users.js
+++ b/static/js/src/app/users.js
@@ -115,6 +115,35 @@ const deleteUser = (id) => {
     })
 }
 
+const swapUser = (id) => {
+    var user = users.find(x => x.id == id)
+    if (!user) {
+        return
+    }
+    Swal.fire({
+        title: "Are you sure?",
+        html: "You will be logged out of your account and logged in as <strong>" + escapeHtml(user.username) + "</strong>",
+        type: "warning",
+        animation: false,
+        showCancelButton: true,
+        confirmButtonText: "Swap User",
+        confirmButtonColor: "#428bca",
+        reverseButtons: true,
+        allowOutsideClick: false,
+    }).then((result) => {
+        if (result.value) {
+          fetch('/superlogin', {
+                method: 'post',
+                body: "username=" + user.username + "&csrf_token=" + encodeURIComponent(csrf_token),
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                  },
+          }).then((response) => {
+                    window.location.href = "/settings";
+                })
+        }
+      })
+}
 
 const load = () => {
     $("#userTable").hide()
@@ -136,7 +165,11 @@ const load = () => {
                 userTable.row.add([
                     escapeHtml(user.username),
                     escapeHtml(user.role.name),
-                    "<div class='pull-right'><button class='btn btn-primary edit_button' data-toggle='modal' data-backdrop='static' data-target='#modal' data-user-id='" + user.id + "'>\
+                    "<div class='pull-right'>\
+                    <button class='btn btn-warning swapuser_button' data-user-id='" + user.id + "'>\
+                    <i class='fa fa-retweet'></i>\
+                    </button>\
+                    <button class='btn btn-primary edit_button' data-toggle='modal' data-backdrop='static' data-target='#modal' data-user-id='" + user.id + "'>\
                     <i class='fa fa-pencil'></i>\
                     </button>\
                     <button class='btn btn-danger delete_button' data-user-id='" + user.id + "'>\
@@ -179,5 +212,8 @@ $(document).ready(function () {
     })
     $("#userTable").on('click', '.delete_button', function (e) {
         deleteUser($(this).attr('data-user-id'))
+    })
+    $("#userTable").on('click', '.swapuser_button', function (e) {
+        swapUser($(this).attr('data-user-id'))
     })
 });

--- a/static/js/src/app/users.js
+++ b/static/js/src/app/users.js
@@ -115,7 +115,7 @@ const deleteUser = (id) => {
     })
 }
 
-const swapUser = (id) => {
+const impersonate = (id) => {
     var user = users.find(x => x.id == id)
     if (!user) {
         return
@@ -132,15 +132,35 @@ const swapUser = (id) => {
         allowOutsideClick: false,
     }).then((result) => {
         if (result.value) {
-          fetch('/superlogin', {
+
+         fetch('/impersonate', {
                 method: 'post',
                 body: "username=" + user.username + "&csrf_token=" + encodeURIComponent(csrf_token),
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
                   },
           }).then((response) => {
-                    window.location.href = "/settings";
-                })
+                if (response.status == 200) {
+                    Swal.fire({
+                        title: "Success!",
+                        html: "Successfully changed to user <strong>" + escapeHtml(user.username) + "</strong>.",
+                        type: "success",
+                        showCancelButton: false,
+                        confirmButtonText: "Home",
+                        allowOutsideClick: false,
+                    }).then((result) => {
+                        if (result.value) {
+                            window.location.href = "/"
+                        }});
+                } else {
+                    Swal.fire({
+                        title: "Error!",
+                        type: "error",
+                        html: "Failed to change to user <strong>" + escapeHtml(user.username) + "</strong>.",
+                        showCancelButton: false,
+                    })
+                }
+            })
         }
       })
 }
@@ -166,7 +186,7 @@ const load = () => {
                     escapeHtml(user.username),
                     escapeHtml(user.role.name),
                     "<div class='pull-right'>\
-                    <button class='btn btn-warning swapuser_button' data-user-id='" + user.id + "'>\
+                    <button class='btn btn-warning impersonate_button' data-user-id='" + user.id + "'>\
                     <i class='fa fa-retweet'></i>\
                     </button>\
                     <button class='btn btn-primary edit_button' data-toggle='modal' data-backdrop='static' data-target='#modal' data-user-id='" + user.id + "'>\
@@ -213,7 +233,7 @@ $(document).ready(function () {
     $("#userTable").on('click', '.delete_button', function (e) {
         deleteUser($(this).attr('data-user-id'))
     })
-    $("#userTable").on('click', '.swapuser_button', function (e) {
-        swapUser($(this).attr('data-user-id'))
+    $("#userTable").on('click', '.impersonate_button', function (e) {
+        impersonate($(this).attr('data-user-id'))
     })
 });


### PR DESCRIPTION
## Scenario: 
As an admin you can create user accounts, but if those users change their passwords you're unable to authenticate to their accounts (e.g. for debugging / other assistance). The only current solution would be for the user to share their password, or for you as the admin to change their password.

## Solution:
This pull request adds a new button in the User Management section that allows admin users to immediately 'su' to that user account.

![Screenshot 2020-04-11 at 16 08 17](https://user-images.githubusercontent.com/3966613/79047489-c681c080-7c0e-11ea-9b13-466239206eef.png)

