### PR TITLE
Add capability to run the binary in a mode

### DIFF
--- a/gophish.go
+++ b/gophish.go
@@ -26,6 +26,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -40,9 +41,17 @@ import (
 	"github.com/gophish/gophish/models"
 )
 
+const (
+	modeAll   string = "all"
+	modeAdmin string = "admin"
+	modePhish string = "phish"
+)
+
 var (
 	configPath    = kingpin.Flag("config", "Location of config.json.").Default("./config.json").String()
 	disableMailer = kingpin.Flag("disable-mailer", "Disable the mailer (for use with multi-system deployments)").Bool()
+	mode          = kingpin.Flag("mode", fmt.Sprintf("Run the binary in one of the modes (%s, %s or %s)", modeAll, modeAdmin, modePhish)).
+			Default("all").Enum(modeAll, modeAdmin, modePhish)
 )
 
 func main() {
@@ -102,18 +111,25 @@ func main() {
 	phishServer := controllers.NewPhishingServer(phishConfig)
 
 	imapMonitor := imap.NewMonitor()
-
-	go adminServer.Start()
-	go phishServer.Start()
-	go imapMonitor.Start()
+	if *mode == "admin" || *mode == "all" {
+		go adminServer.Start()
+		go imapMonitor.Start()
+	}
+	if *mode == "phish" || *mode == "all" {
+		go phishServer.Start()
+	}
 
 	// Handle graceful shutdown
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	<-c
 	log.Info("CTRL+C Received... Gracefully shutting down servers")
-	adminServer.Shutdown()
-	phishServer.Shutdown()
-	imapMonitor.Shutdown()
+	if *mode == modeAdmin || *mode == modeAll {
+		adminServer.Shutdown()
+		imapMonitor.Shutdown()
+	}
+	if *mode == modePhish || *mode == modeAll {
+		phishServer.Shutdown()
+	}
 
 }


### PR DESCRIPTION
These commit includes changes to start the server as one of admin (also
IMAP) or phish server. Before this change the servers used to run in
monolith this change will decouple the two core component i.e. admin
and phish server so that they can be run independently.

This will help where admin and phish server are required to run
saperately e.g. phish server runs in a DMZ.

The available modes are `admin`, `phish` and `all`. Running the binary
in the `admin` mode will start the admin and IMAP server, while running
the binary in the `phish` mode will start the phish server. `all` mode,
which is also the default mode will start admin, IMAP and phish servers.
e.g. `go run gophish.go --mode admin`