### PR TITLE
Use GroupsSummary to create and copy campaign

### DIFF
--- a/static/js/src/app/campaigns.js
+++ b/static/js/src/app/campaigns.js
@@ -162,15 +162,16 @@ function deleteCampaign(idx) {
 }
 
 function setupOptions() {
-    api.groups.get()
-        .success(function (groups) {
+    api.groups.summary()
+        .success(function (summaries) {
+            groups = summaries.groups
             if (groups.length == 0) {
                 modalError("No groups found!")
                 return false;
             } else {
                 var group_s2 = $.map(groups, function (obj) {
                     obj.text = obj.name
-                    obj.title = obj.targets.length + " targets"
+                    obj.title = obj.num_targets + " targets"
                     return obj
                 });
                 console.log(group_s2)


### PR DESCRIPTION
The Groups (get all groups and associated targets) call is used while
loading modal for creating and copying a campaign. As Groups API gets
all the associated targets for a groups as well, it slows system
considerably if there are large number of groups and targets (~200
groups each with ~100-10000 targets).
As targets are not really needed in this workflow, this call can be
replaced by GroupsSummary call.