### PR TITLE
Add ability to provide initial API key on service standup

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -34,6 +34,11 @@ const DefaultAdminUsername = "admin"
 // randomly
 const InitialAdminPassword = "GOPHISH_INITIAL_ADMIN_PASSWORD"
 
+// InitialAdminApiToken is the environment variable that specifies the
+// API token to seed the initial root login instead of generating one
+// randomly
+const InitialAdminApiToken = "GOPHISH_INITIAL_ADMIN_API_TOKEN"
+
 const (
 	CampaignInProgress string = "In progress"
 	CampaignQueued     string = "Queued"
@@ -208,7 +213,13 @@ func Setup(c *config.Config) error {
 			RoleID:                 adminRole.ID,
 			PasswordChangeRequired: true,
 		}
-		adminUser.ApiKey = auth.GenerateSecureKey(auth.APIKeyLength)
+
+		if envToken := os.Getenv(InitialAdminApiToken); envToken != "" {
+			adminUser.ApiKey = envToken
+		} else {
+			adminUser.ApiKey = auth.GenerateSecureKey(auth.APIKeyLength)
+		}
+
 		err = db.Save(&adminUser).Error
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
This commit follows the same pattern used by GOPHISH_INITIAL_ADMIN_PASSWORD but lets you set the initial API key.  This doesn't change the security model any since someone could still automate their way to an API key with the initial password, this just makes the process easy and more reliable.

I'm working in an environment where I want to completely automate everything around gophish.  The service standup, campaigns, etc.  This change lets me do this and stick only to documented APIs.