### PR TITLE
Added functionality to display last user login

### DIFF
--- a/controllers/route.go
+++ b/controllers/route.go
@@ -382,6 +382,10 @@ func (as *AdminServer) Login(w http.ResponseWriter, r *http.Request) {
 			as.handleInvalidLogin(w, r)
 			return
 		}
+		err = models.UpdateLastLogin(username)
+		if err != nil {
+			log.Error(err)
+		}
 		// If we've logged in, save the session and redirect to the dashboard
 		session.Values["id"] = u.Id
 		session.Save(r, w)

--- a/controllers/route.go
+++ b/controllers/route.go
@@ -382,7 +382,8 @@ func (as *AdminServer) Login(w http.ResponseWriter, r *http.Request) {
 			as.handleInvalidLogin(w, r)
 			return
 		}
-		err = models.UpdateLastLogin(username)
+		u.LastLogin = time.Now().UTC()
+		err = models.PutUser(&u)
 		if err != nil {
 			log.Error(err)
 		}

--- a/db/db_mysql/migrations/20200914000000_0.11.0_last_login.sql
+++ b/db/db_mysql/migrations/20200914000000_0.11.0_last_login.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE `users` ADD COLUMN last_login datetime;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back

--- a/db/db_sqlite3/migrations/20200914000000_0.11.0_last_login.sql
+++ b/db/db_sqlite3/migrations/20200914000000_0.11.0_last_login.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE users ADD COLUMN last_login datetime;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back

--- a/models/user.go
+++ b/models/user.go
@@ -55,18 +55,6 @@ func GetUserByUsername(username string) (User, error) {
 	return u, err
 }
 
-// UpdateLastLogin updates the timestamp for the last successful login for a user
-func UpdateLastLogin(username string) error {
-	u := User{}
-	err := db.Where("username=?", username).First(&u).Error
-	if err != nil {
-		return err
-	}
-	u.LastLogin = time.Now().UTC()
-	err = db.Save(u).Error
-	return err
-}
-
 // PutUser updates the given user
 func PutUser(u *User) error {
 	err := db.Save(u).Error

--- a/models/user.go
+++ b/models/user.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"errors"
+	"time"
 
 	log "github.com/gophish/gophish/logger"
 )
@@ -13,13 +14,14 @@ var ErrModifyingOnlyAdmin = errors.New("Cannot remove the only administrator")
 
 // User represents the user model for gophish.
 type User struct {
-	Id                     int64  `json:"id"`
-	Username               string `json:"username" sql:"not null;unique"`
-	Hash                   string `json:"-"`
-	ApiKey                 string `json:"api_key" sql:"not null;unique"`
-	Role                   Role   `json:"role" gorm:"association_autoupdate:false;association_autocreate:false"`
-	RoleID                 int64  `json:"-"`
-	PasswordChangeRequired bool   `json:"password_change_required"`
+	Id                     int64     `json:"id"`
+	Username               string    `json:"username" sql:"not null;unique"`
+	Hash                   string    `json:"-"`
+	ApiKey                 string    `json:"api_key" sql:"not null;unique"`
+	Role                   Role      `json:"role" gorm:"association_autoupdate:false;association_autocreate:false"`
+	RoleID                 int64     `json:"-"`
+	PasswordChangeRequired bool      `json:"password_change_required"`
+	LastLogin              time.Time `json:"last_login"`
 }
 
 // GetUser returns the user that the given id corresponds to. If no user is found, an
@@ -51,6 +53,18 @@ func GetUserByUsername(username string) (User, error) {
 	u := User{}
 	err := db.Preload("Role").Where("username = ?", username).First(&u).Error
 	return u, err
+}
+
+// UpdateLastLogin updates the timestamp for the last successful login for a user
+func UpdateLastLogin(username string) error {
+	u := User{}
+	err := db.Where("username=?", username).First(&u).Error
+	if err != nil {
+		return err
+	}
+	u.LastLogin = time.Now().UTC()
+	err = db.Save(u).Error
+	return err
 }
 
 // PutUser updates the given user

--- a/static/js/src/app/users.js
+++ b/static/js/src/app/users.js
@@ -185,9 +185,14 @@ const load = () => {
             userTable.clear();
             userRows = []
             $.each(users, (i, user) => {
+                lastlogin = "Never"
+                if (user.last_login != "0001-01-01T00:00:00Z") {
+                    lastlogin = moment(user.last_login).format('MMMM Do YYYY, h:mm:ss a')
+                }
                 userRows.push([
                     escapeHtml(user.username),
                     escapeHtml(user.role.name),
+                    lastlogin,
                     "<div class='pull-right'>\
                     <button class='btn btn-warning impersonate_button' data-user-id='" + user.id + "'>\
                     <i class='fa fa-retweet'></i>\

--- a/templates/users.html
+++ b/templates/users.html
@@ -23,6 +23,7 @@
                 <tr>
                     <th>Username</th>
                     <th>Role</th>
+                    <th>Last Login</th>
                     <th class="col-md-2 no-sort"></th>
                 </tr>
             </thead>


### PR DESCRIPTION
This pull request adds a column to the `Users & Groups` section to display the last successful login of each user:

<img width="1162" alt="lastlogin" src="https://user-images.githubusercontent.com/3966613/93079215-10724500-f68c-11ea-9fb0-4f4194cd5667.png">

I'm not sure if the database update logic should be in `models.user`. It didn't feel right putting in `auth` as there are no other database interactions there.