### PR TITLE
Modified regex to detect Microsoft ATP URLs

### DIFF
--- a/imap/monitor.go
+++ b/imap/monitor.go
@@ -21,8 +21,10 @@ import (
 	"github.com/gophish/gophish/models"
 )
 
-// Pattern for GoPhish emails e.g ?rid=AbC123
-var goPhishRegex = regexp.MustCompile("(\\?rid=(3D)?([A-Za-z0-9]{7}))") // We include the optional quoted-printable 3D at the front, just in case decoding fails
+// Pattern for GoPhish emails e.g ?rid=AbC1234
+// We include the optional quoted-printable 3D at the front, just in case decoding fails. e.g ?rid=3DAbC1234
+// We also include alternative URL encoded representations of '=' and '?' to handle Microsoft ATP URLs e.g %3Frid%3DAbC1234
+var goPhishRegex = regexp.MustCompile("((\\?|%3F)rid(=|%3D)(3D)?([A-Za-z0-9]{7}))")
 
 // Monitor is a worker that monitors IMAP servers for reported campaign emails
 type Monitor struct {


### PR DESCRIPTION
Fix to address https://github.com/gophish/gophish/issues/1975

Test code for the regex:

```
package main

import (
	"fmt"
	"regexp"
)

func main() {


	var goPhishRegex = regexp.MustCompile("((\\?|%3F)rid(=|%3D)(3D)?([A-Za-z0-9]{7}))")


	testCases := [...]string{"hello world no rids here", "blah ?rid=AbC1234 blah", "blah ?rid=3DAbC1234 blah", "blah %3Frid%3DAbC1234 blah", "blah %3Frid%3D3DAbC1234 blah"}

	for i, emailContent := range testCases {

	  fmt.Printf("Test %d: ", i)
	  for _, r := range goPhishRegex.FindAllStringSubmatch(emailContent, -1) {
	    newrid := r[len(r)-1]
	    fmt.Printf(newrid)
	  }
	  fmt.Println()
	}

}
```

```
Test 0: 
Test 1: AbC1234
Test 2: AbC1234
Test 3: AbC1234
Test 4: AbC1234
```


https://play.golang.org/p/QmsWHgPRmQR