### PR TITLE
Add PUT and DELETE methods for CORS handling.

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -77,7 +77,7 @@ func RequireAPIKey(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		if r.Method == "OPTIONS" {
-			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
 			w.Header().Set("Access-Control-Max-Age", "1000")
 			w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
 			return

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -133,6 +133,18 @@ func TestRequireAPIKey(t *testing.T) {
 	}
 }
 
+func TestCORSHeaders(t *testing.T) {
+	setupTest(t)
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	response := httptest.NewRecorder()
+	RequireAPIKey(successHandler).ServeHTTP(response, req)
+	expected := "POST, GET, OPTIONS, PUT, DELETE"
+	got := response.Result().Header.Get("Access-Control-Allow-Methods")
+	if got != expected {
+		t.Fatalf("incorrect cors options received. expected %s got %s", expected, got)
+	}
+}
+
 func TestInvalidAPIKey(t *testing.T) {
 	setupTest(t)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)


### PR DESCRIPTION
This PR adds the `PUT` and `DELETE` methods as valid for CORS handling, fixing #2098.