### PR TITLE
Support for SMTPUTF8 (and homoglyph attacks)

### DIFF
--- a/db/db_mysql/migrations/20210205103800_0.11.0_use_smtputf8.sql
+++ b/db/db_mysql/migrations/20210205103800_0.11.0_use_smtputf8.sql
@@ -1,0 +1,8 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE `smtp` ADD COLUMN use_smtputf8 BOOLEAN;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+

--- a/db/db_sqlite3/migrations/20210205103800_0.11.0_use_smtputf8.sql
+++ b/db/db_sqlite3/migrations/20210205103800_0.11.0_use_smtputf8.sql
@@ -1,0 +1,8 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE smtp ADD COLUMN use_smtputf8 BOOLEAN;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/emersion/go-imap v1.0.4
 	github.com/emersion/go-message v0.12.0
+	github.com/emersion/go-smtp v0.14.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gophish/gomail v0.0.0-20200818021916-1f6d0dfd512e
 	github.com/gorilla/context v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,11 @@ github.com/emersion/go-imap v1.0.4/go.mod h1:yKASt+C3ZiDAiCSssxg9caIckWF/JG7ZQTO
 github.com/emersion/go-message v0.11.1/go.mod h1:C4jnca5HOTo4bGN9YdqNQM9sITuT3Y0K6bSUw9RklvY=
 github.com/emersion/go-message v0.12.0 h1:mZnv35eZ6lB6EftTQBgYXspOH0FQdhpFhSUhA9i6/Zg=
 github.com/emersion/go-message v0.12.0/go.mod h1:C4jnca5HOTo4bGN9YdqNQM9sITuT3Y0K6bSUw9RklvY=
-github.com/emersion/go-sasl v0.0.0-20191210011802-430746ea8b9b h1:uhWtEWBHgop1rqEk2klKaxPAkVDCXexai6hSuRQ7Nvs=
 github.com/emersion/go-sasl v0.0.0-20191210011802-430746ea8b9b/go.mod h1:G/dpzLu16WtQpBfQ/z3LYiYJn3ZhKSGWn83fyoyQe/k=
+github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21 h1:OJyUGMJTzHTd1XQp98QTaHernxMYzRaOasRir9hUlFQ=
+github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
+github.com/emersion/go-smtp v0.14.0 h1:RYW203p+EcPjL8Z/ZpT9lZ6iOc8MG1MQzEx1UKEkXlA=
+github.com/emersion/go-smtp v0.14.0/go.mod h1:qm27SGYgoIPRot6ubfQ/GpiPy/g3PaZAVRxiO/sDUgQ=
 github.com/emersion/go-textwrapper v0.0.0-20160606182133-d0e65e56babe h1:40SWqY0zE3qCi6ZrtTf5OUdNm5lDnGnjRSq9GgmeTrg=
 github.com/emersion/go-textwrapper v0.0.0-20160606182133-d0e65e56babe/go.mod h1:aqO8z8wPrjkscevZJFVE1wXJrLpC5LtJG7fqLOsPb2U=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=

--- a/models/smtp.go
+++ b/models/smtp.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/emersion/go-smtp"
 	"github.com/gophish/gomail"
 	"github.com/gophish/gophish/dialer"
 	log "github.com/gophish/gophish/logger"
@@ -40,6 +41,7 @@ type SMTP struct {
 	Password         string    `json:"password,omitempty"`
 	FromAddress      string    `json:"from_address"`
 	IgnoreCertErrors bool      `json:"ignore_cert_errors"`
+	UseSMTPUTF8      bool      `json:"use_smtputf8"`
 	Headers          []Header  `json:"headers"`
 	ModifiedDate     time.Time `json:"modified_date"`
 }
@@ -115,6 +117,9 @@ func (s *SMTP) GetDialer() (mailer.Dialer, error) {
 	d.TLSConfig = &tls.Config{
 		ServerName:         host,
 		InsecureSkipVerify: s.IgnoreCertErrors,
+	}
+	d.MailOptions = &smtp.MailOptions{
+		UTF8: s.UseSMTPUTF8,
 	}
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/static/js/src/app/sending_profiles.js
+++ b/static/js/src/app/sending_profiles.js
@@ -22,6 +22,7 @@ function sendTestEmail() {
             username: $("#username").val(),
             password: $("#password").val(),
             ignore_cert_errors: $("#ignore_cert_errors").prop("checked"),
+            use_smtputf8: $("#use_smtputf8").prop("checked"),
             headers: headers,
         }
     }
@@ -59,6 +60,7 @@ function save(idx) {
     profile.username = $("#username").val()
     profile.password = $("#password").val()
     profile.ignore_cert_errors = $("#ignore_cert_errors").prop("checked")
+    profile.use_smtputf8 = $("#use_smtputf8").prop("checked")
     if (idx != -1) {
         profile.id = profiles[idx].id
         api.SMTPId.put(profile)
@@ -93,6 +95,7 @@ function dismiss() {
     $("#username").val("")
     $("#password").val("")
     $("#ignore_cert_errors").prop("checked", true)
+    $("#use_smtputf8").prop("checked", false)
     $("#headersTable").dataTable().DataTable().clear().draw()
     $("#modal").modal('hide')
 }
@@ -161,6 +164,7 @@ function edit(idx) {
         $("#username").val(profile.username)
         $("#password").val(profile.password)
         $("#ignore_cert_errors").prop("checked", profile.ignore_cert_errors)
+        $("#use_smtputf8").prop("checked", profile.use_smtputf8)
         $.each(profile.headers, function (i, record) {
             addCustomHeader(record.key, record.value)
         });
@@ -180,6 +184,7 @@ function copy(idx) {
     $("#username").val(profile.username)
     $("#password").val(profile.password)
     $("#ignore_cert_errors").prop("checked", profile.ignore_cert_errors)
+    $("#use_smtputf8").prop("checked", profile.use_smtputf8)
 }
 
 function load() {

--- a/templates/sending_profiles.html
+++ b/templates/sending_profiles.html
@@ -63,6 +63,11 @@
                         <label for="ignore_cert_errors">Ignore Certificate Errors <i class="fa fa-question-circle"
                                 data-toggle="tooltip" data-placement="right" title="Ignore common certificate errors such as self-signed certs (exposes you to MiTM attacks - use carefully!)"></i></label>
                     </div>
+                    <div class="checkbox checkbox-primary">
+                        <input id="use_smtputf8" type="checkbox">
+                        <label for="use_smtputf8">Use SMTPUTF8 <i class="fa fa-question-circle"
+                                data-toggle="tooltip" data-placement="right" title="SMTPUTF8 enables using UTF-8 chars in From address. It must be supported by both sender and receiver mail servers."></i></label>
+                    </div>
                     <label class="control-label" for="headersForm">Email Headers:</label>
                     <form id="headersForm">
                         <div class="col-md-4">


### PR DESCRIPTION
Support for SMTPUTF8 will help Gophish users to perform homoglyph attacks.
However, this need both the sender SMTP server and the recipient mail server to support SMTPUTF8 (successfully tested with Office 365 and Gmail). Following Gophish test mail is usurping google.com domain (using the ọ char, which is not converted to punnycode) :

![result](https://user-images.githubusercontent.com/1941583/106937484-17265500-671e-11eb-8852-76e5ff3652da.png)

It depends on PR https://github.com/gophish/gomail/pull/3 for SMTP implementation.

PR add following option in Sender profile (default is unchecked) : 


![image](https://user-images.githubusercontent.com/1941583/106937914-9e73c880-671e-11eb-9cfe-9dbcd5696496.png)

If support is not enabled on sender SMTP server : 

![error](https://user-images.githubusercontent.com/1941583/106937412-01b12b00-671e-11eb-9746-5a943a1a6695.png)

