### PR TITLE
Allow setting .db_name via environment

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -60,6 +60,12 @@ if [ -n "${CONTACT_ADDRESS+set}" ] ; then
         cat config.json.tmp > config.json
 fi
 
+if [ -n "${DB_NAME+set}" ] ; then
+    jq -r \
+        --arg DB_NAME "${DB_NAME}" \
+        '.db_name = $DB_NAME' config.json > config.json.tmp && \
+        cat config.json.tmp > config.json
+fi
 if [ -n "${DB_FILE_PATH+set}" ] ; then
     jq -r \
         --arg DB_FILE_PATH "${DB_FILE_PATH}" \


### PR DESCRIPTION
Using mysql requires this variable to be set however when running in a container you couldnt easily set its value