### PR TITLE
Fix open redirect vulnerability on the login page

### DIFF
--- a/controllers/route.go
+++ b/controllers/route.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/NYTimes/gziphandler"
@@ -296,9 +297,9 @@ func (as *AdminServer) nextOrIndex(w http.ResponseWriter, r *http.Request) {
 	next := "/"
 	url, err := url.Parse(r.FormValue("next"))
 	if err == nil {
-		path := url.Path
+		path := url.EscapedPath()
 		if path != "" {
-			next = path
+			next = "/" + strings.TrimLeft(path, "/")
 		}
 	}
 	http.Redirect(w, r, next, http.StatusFound)


### PR DESCRIPTION
This PR fixes Open Redirect vulnerability in `next` query parameter of login and reset password pages.

To reproduce this issue you need to open `https://localhost:3333/login?next=\\\\\\example.com` and then login. You are going to be redirected to `https://example.com`.

@jordan-wright and I had a discussion about this vulnerability in email.