### PR TITLE
Add Trusted Origins to CSRF Handler

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,8 @@
 		"listen_url": "127.0.0.1:3333",
 		"use_tls": true,
 		"cert_path": "gophish_admin.crt",
-		"key_path": "gophish_admin.key"
+		"key_path": "gophish_admin.key",
+		"trusted_origins": ""
 	},
 	"phish_server": {
 		"listen_url": "0.0.0.0:80",

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
 		"use_tls": true,
 		"cert_path": "gophish_admin.crt",
 		"key_path": "gophish_admin.key",
-		"trusted_origins": ""
+		"trusted_origins": []
 	},
 	"phish_server": {
 		"listen_url": "0.0.0.0:80",

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type AdminServer struct {
 	KeyPath              string   `json:"key_path"`
 	CSRFKey              string   `json:"csrf_key"`
 	AllowedInternalHosts []string `json:"allowed_internal_hosts"`
+	TrustedOrigins       []string `json:"trusted_origins"`
 }
 
 // PhishServer represents the Phish server configuration details

--- a/controllers/route.go
+++ b/controllers/route.go
@@ -154,7 +154,8 @@ func (as *AdminServer) registerRoutes() {
 	}
 	csrfHandler := csrf.Protect(csrfKey,
 		csrf.FieldName("csrf_token"),
-		csrf.Secure(as.config.UseTLS))
+		csrf.Secure(as.config.UseTLS),
+		csrf.TrustedOrigins(as.config.TrustedOrigins))
 	adminHandler := csrfHandler(router)
 	adminHandler = mid.Use(adminHandler.ServeHTTP, mid.CSRFExceptions, mid.GetContext, mid.ApplySecurityHeaders)
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -25,6 +25,12 @@ if [ -n "${ADMIN_KEY_PATH+set}" ] ; then
         '.admin_server.key_path = $ADMIN_KEY_PATH' config.json > config.json.tmp && \
         cat config.json.tmp > config.json
 fi
+if [ -n "${ADMIN_TRUSTED_ORIGINS+set}" ] ; then
+    jq -r \
+        --arg ADMIN_TRUSTED_ORIGINS "${ADMIN_TRUSTED_ORIGINS}" \
+        '.admin_server.trusted_origins = ($ADMIN_TRUSTED_ORIGINS|split(","))' config.json > config.json.tmp && \
+        cat config.json.tmp > config.json
+fi
 
 # set config for phish_server
 if [ -n "${PHISH_LISTEN_URL+set}" ] ; then


### PR DESCRIPTION
With a load balancer acting as TLS-termination for the application, there have been issues where the underlying application runs into a CSRF issue:
- https://github.com/gophish/gophish/issues/2003
- https://github.com/gophish/gophish/issues/2107

In particular, it comes from the CSRF handler seeing the `Referer` header passed through as an invalid origin. This ultimately depends on how your load balancer does its negotiation. Since the application is unaware of the load balancer's existence, the application sees the forwarded request from a host it doesn't understand, and returns a 403.

To fix this, explicitly state that there are origins that we will expect requests to come from. It's assumed to be a comma-delimited string, because I didn't know how to translate multiple environment variables into a string array using `jq`.

Happy to work a bit more (tests, docs, etc.) to get this in.