### PR TITLE
Fix sending profile form (fixes #1986)

### DIFF
--- a/static/js/src/app/sending_profiles.js
+++ b/static/js/src/app/sending_profiles.js
@@ -307,7 +307,7 @@ $(document).ready(function () {
         dismissSendTestEmailModal()
     })
     // Code to deal with custom email headers
-    $("#headersForm").on('submit', function () {
+    $("#addCustomHeader").on('click', function () {
         headerKey = $("#headerKey").val();
         headerValue = $("#headerValue").val();
 
@@ -316,7 +316,8 @@ $(document).ready(function () {
         }
         addCustomHeader(headerKey, headerValue);
         // Reset user input.
-        $("#headersForm>div>input").val('');
+        $("#headerKey").val('');
+        $("#headerValue").val('');
         $("#headerKey").focus();
         return false;
     });

--- a/templates/sending_profiles.html
+++ b/templates/sending_profiles.html
@@ -44,27 +44,29 @@
             </div>
             <div class="modal-body">
                 <div class="row" id="modal.flashes"></div>
-                <div class="form-group">
-                    <label class="control-label" for="name">Name:</label>
-                    <input type="text" class="form-control" placeholder="Profile name" id="name" autofocus />
-                    <label class="control-label" for="interface_type">Interface Type:</label>
-                    <input type="text" class="form-control" value="SMTP" id="interface_type" disabled />
-                    <label class="control-label" for="from">From:</label>
-                    <input type="text" class="form-control" placeholder="First Last <test@example.com>" id="from"
-                        required />
-                    <label class="control-label" for="host">Host:</label>
-                    <input type="text" class="form-control" placeholder="smtp.example.com:25" id="host" required />
-                    <label class="control-label" for="username">Username:</label>
-                    <input type="text" class="form-control" placeholder="Username" id="username" />
-                    <label class="control-label" for="password">Password:</label>
-                    <input type="password" class="form-control" placeholder="Password" id="password" />
-                    <div class="checkbox checkbox-primary">
-                        <input id="ignore_cert_errors" type="checkbox" checked>
-                        <label for="ignore_cert_errors">Ignore Certificate Errors <i class="fa fa-question-circle"
-                                data-toggle="tooltip" data-placement="right" title="Ignore common certificate errors such as self-signed certs (exposes you to MiTM attacks - use carefully!)"></i></label>
+                <form>
+                    <div class="form-group">
+                        <label class="control-label" for="name">Name:</label>
+                        <input type="text" class="form-control" placeholder="Profile name" id="name" autofocus />
+                        <label class="control-label" for="interface_type">Interface Type:</label>
+                        <input type="text" class="form-control" value="SMTP" id="interface_type" disabled />
+                        <label class="control-label" for="from">From:</label>
+                        <input type="text" class="form-control" placeholder="First Last <test@example.com>" id="from"
+                            required />
+                        <label class="control-label" for="host">Host:</label>
+                        <input type="text" class="form-control" placeholder="smtp.example.com:25" id="host" required />
+                        <label class="control-label" for="username">Username:</label>
+                        <input type="text" class="form-control" placeholder="Username" id="username" />
+                        <label class="control-label" for="password">Password:</label>
+                        <input type="password" class="form-control" placeholder="Password" id="password" />
+                        <div class="checkbox checkbox-primary">
+                            <input id="ignore_cert_errors" type="checkbox" checked>
+                            <label for="ignore_cert_errors">Ignore Certificate Errors <i class="fa fa-question-circle"
+                                    data-toggle="tooltip" data-placement="right" title="Ignore common certificate errors such as self-signed certs (exposes you to MiTM attacks - use carefully!)"></i></label>
+                        </div>
                     </div>
-                    <label class="control-label" for="headersForm">Email Headers:</label>
-                    <form id="headersForm">
+                    <fieldset class="form-group">
+                        <label class="control-label input-group">Email Headers:</label>
                         <div class="col-md-4">
                             <input type="text" class="form-control" name="headerKey" id="headerKey" placeholder="X-Custom-Header">
                         </div>
@@ -72,12 +74,10 @@
                             <input type="text" class="form-control" name="headerValue" id="headerValue" placeholder='{{"{{"}}.URL{{"}}"}}-gophish'>
                         </div>
                         <div class="col-md-2">
-                            <button class="btn btn-danger btn-headers" type="submit"><i class="fa fa-plus"></i> Add
+                            <button id="addCustomHeader" class="btn btn-danger btn-headers" type="button"><i class="fa fa-plus"></i> Add
                                 Custom Header</button>
                         </div>
-                    </form>
-                    <br />
-                    <br />
+                    </fieldset>
                     <table id="headersTable" class="table table-hover table-striped table-condensed">
                         <thead>
                             <tr>
@@ -91,7 +91,7 @@
                     </table>
                     <button type="button" data-toggle="modal" data-backdrop="static" data-target="#sendTestEmailModal"
                         class="btn btn-primary"><i class="fa fa-envelope"></i> Send Test Email</button>
-                </div>
+                </form>
             </div>
             <div class="modal-footer">
                 <button type="button" data-dismiss="modal" class="btn btn-default" onclick="dismiss()">Cancel</button>


### PR DESCRIPTION
Wrap all inputs on the New Sending Profile page in a `<form>`, as bootstrap and HTML5 advise. This fixes the annoying behaviour in Chrome where it tries to autofill the search box as a username for the password field. Other pages are also missing forms, but they don't have this problem because they don't have password fields.

I've used `<label class="input-group">`, which is strictly wrong, but the correct `<legend>` would be much larger. Bootstrap 4 will make it easier to make the legend a sensible size.

As a side-effect, these changes stop enter from adding a custom email header (as the button is no longer the submit for the form). Instead, a user must tab into the Add Custom Header button before pressing enter/space. I think this is less surprising, as enter for a popup form typically submits the entire form. I can change this if necessary.