### PR TITLE
Fix resource selection during campaign copy

### DIFF
--- a/static/js/src/app/campaigns.js
+++ b/static/js/src/app/campaigns.js
@@ -257,6 +257,7 @@ function copy(idx) {
         .success(function (campaign) {
             $("#name").val("Copy of " + campaign.name)
             if (!campaign.template.id) {
+                $("#template").val("").change();
                 $("#template").select2({
                     placeholder: campaign.template.name
                 });
@@ -265,6 +266,7 @@ function copy(idx) {
                 $("#template").trigger("change.select2")
             }
             if (!campaign.page.id) {
+                $("#page").val("").change();
                 $("#page").select2({
                     placeholder: campaign.page.name
                 });
@@ -273,6 +275,7 @@ function copy(idx) {
                 $("#page").trigger("change.select2")
             }
             if (!campaign.smtp.id) {
+                $("#profile").val("").change();
                 $("#profile").select2({
                     placeholder: campaign.smtp.name
                 });


### PR DESCRIPTION
Clear the selection of resource (template, page, profile) whenever the original resource is deleted and there is
only one currently available resource present in the DB while copying a campaign. Without this fix, the only
available resource is shown as the original resource, instead of showing [Deleted].