### PR TITLE
Add configurable list of filetypes that allow substitutions in attachments

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,5 +19,17 @@
 	"logging": {
 		"filename": "",
 		"level": ""
+	},
+	"attachments": {
+		"plain_text_file_list": [
+			".txt",
+			".html",
+			".ics",
+			".ps1",
+			".bat",
+			".vbs",
+			".sh",
+			".py"
+		]
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,11 @@ type PhishServer struct {
 	KeyPath   string `json:"key_path"`
 }
 
+// Attachments represents the handling of attachments in emails
+type Attachments struct {
+	PlainTextFileList []string `json:"plain_text_file_list"`
+}
+
 // Config represents the configuration information.
 type Config struct {
 	AdminConf      AdminServer `json:"admin_server"`
@@ -37,6 +42,7 @@ type Config struct {
 	TestFlag       bool        `json:"test_flag"`
 	ContactAddress string      `json:"contact_address"`
 	Logging        *log.Config `json:"logging"`
+	Attachments    Attachments `json:"attachments"`
 }
 
 // Version contains the current gophish version

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,7 +26,19 @@ var validConfig = []byte(`{
 	"db_name": "sqlite3",
 	"db_path": "gophish.db",
 	"migrations_prefix": "db/db_",
-	"contact_address": ""
+	"contact_address": "",
+	"attachments": {
+		"plain_text_file_list": [
+			".txt",
+			".html",
+			".ics",
+			".ps1",
+			".bat",
+			".vbs",
+			".sh",
+			".py"
+		]
+	}
 }`)
 
 func createTemporaryConfig(t *testing.T) *os.File {


### PR DESCRIPTION
Currently it is possible to add templated microsoft office files as attachments to simulate macro viruses. 
In our use case we also need to be able to send other plain-text executable files such as `.bat` and `.ps1` as an attachment with working template rendering. As this use case differs for each user, this pull request will add the following new configuration to the `config.json` file:
```json
{
...
	"attachments": {
		"plain_text_file_list": [
			".txt",
			".html",
			".ics",
			".ps1",
			".bat",
			".vbs",
			".sh",
			".py"
		]
	}
...
}
```
This allows the user to set a list of allowed files where templates are rendered in attachment files.
As this is my first PR to this repo I am glad for any feedback, please let me know if any of it does not match the current style or naming scheme.
