### PR TITLE
Modified "SMTP From" field to avoid SMTP server errors

### DIFF
--- a/models/maillog_test.go
+++ b/models/maillog_test.go
@@ -284,7 +284,7 @@ func (s *ModelsSuite) TestMailLogGenerateOverrideTransparencyHeaders(ch *check.C
 	smtp := SMTP{
 		Name:        "Test SMTP",
 		Host:        "1.1.1.1:25",
-		FromAddress: "Foo Bar <foo@example.com>",
+		FromAddress: "foo@example.com",
 		UserId:      1,
 		Headers: []Header{
 			Header{Key: "X-Gophish-Contact", Value: ""},

--- a/models/smtp.go
+++ b/models/smtp.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/mail"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -57,6 +58,10 @@ type Header struct {
 // specified in the SMTP configuration
 var ErrFromAddressNotSpecified = errors.New("No From Address specified")
 
+// ErrInvalidFromAddress is thrown when the SMTP From field in the sending
+// profiles containes a value that is not an email address
+var ErrInvalidFromAddress = errors.New("Invalid SMTP From address because it is not an email address")
+
 // ErrHostNotSpecified is thrown when there is no Host specified
 // in the SMTP configuration
 var ErrHostNotSpecified = errors.New("No SMTP Host specified")
@@ -76,6 +81,8 @@ func (s *SMTP) Validate() error {
 		return ErrFromAddressNotSpecified
 	case s.Host == "":
 		return ErrHostNotSpecified
+	case !validateFromAddress(s.FromAddress):
+		return ErrInvalidFromAddress
 	}
 	_, err := mail.ParseAddress(s.FromAddress)
 	if err != nil {
@@ -93,6 +100,12 @@ func (s *SMTP) Validate() error {
 		return ErrInvalidHost
 	}
 	return err
+}
+
+// validateFromAddress validates
+func validateFromAddress(email string) bool {
+	r, _ := regexp.Compile("^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$")
+	return r.MatchString(email)
 }
 
 // GetDialer returns a dialer for the given SMTP profile

--- a/models/smtp_test.go
+++ b/models/smtp_test.go
@@ -12,7 +12,7 @@ func (s *ModelsSuite) TestPostSMTP(c *check.C) {
 	smtp := SMTP{
 		Name:        "Test SMTP",
 		Host:        "1.1.1.1:25",
-		FromAddress: "Foo Bar <foo@example.com>",
+		FromAddress: "foo@example.com",
 		UserId:      1,
 	}
 	err := PostSMTP(&smtp)
@@ -25,7 +25,7 @@ func (s *ModelsSuite) TestPostSMTP(c *check.C) {
 func (s *ModelsSuite) TestPostSMTPNoHost(c *check.C) {
 	smtp := SMTP{
 		Name:        "Test SMTP",
-		FromAddress: "Foo Bar <foo@example.com>",
+		FromAddress: "foo@example.com",
 		UserId:      1,
 	}
 	err := PostSMTP(&smtp)
@@ -42,11 +42,33 @@ func (s *ModelsSuite) TestPostSMTPNoFrom(c *check.C) {
 	c.Assert(err, check.Equals, ErrFromAddressNotSpecified)
 }
 
-func (s *ModelsSuite) TestPostSMTPValidHeader(c *check.C) {
+func (s *ModelsSuite) TestPostInvalidFrom(c *check.C) {
 	smtp := SMTP{
 		Name:        "Test SMTP",
 		Host:        "1.1.1.1:25",
 		FromAddress: "Foo Bar <foo@example.com>",
+		UserId:      1,
+	}
+	err := PostSMTP(&smtp)
+	c.Assert(err, check.Equals, ErrInvalidFromAddress)
+}
+
+func (s *ModelsSuite) TestPostInvalidFromEmail(c *check.C) {
+	smtp := SMTP{
+		Name:        "Test SMTP",
+		Host:        "1.1.1.1:25",
+		FromAddress: "example.com",
+		UserId:      1,
+	}
+	err := PostSMTP(&smtp)
+	c.Assert(err, check.Equals, ErrInvalidFromAddress)
+}
+
+func (s *ModelsSuite) TestPostSMTPValidHeader(c *check.C) {
+	smtp := SMTP{
+		Name:        "Test SMTP",
+		Host:        "1.1.1.1:25",
+		FromAddress: "foo@example.com",
 		UserId:      1,
 		Headers: []Header{
 			Header{Key: "Reply-To", Value: "test@example.com"},

--- a/templates/sending_profiles.html
+++ b/templates/sending_profiles.html
@@ -52,7 +52,7 @@
                         <input type="text" class="form-control" value="SMTP" id="interface_type" disabled />
                         <label class="control-label" for="from">SMTP From: <i class="fa fa-question-circle"
                                 data-toggle="tooltip" data-placement="right" title="Set this to an email address from your sending domain to bypass SPF-checks. You can set the Envelope Sender in Email Templates. The Envelope Sender is shown to the user."></i></label>
-                        <input type="text" class="form-control" placeholder="First Last <test@example.com>" id="from"
+                        <input type="text" class="form-control" placeholder="test@example.com" id="from"
                             required />
                         <label class="control-label" for="host">Host:</label>
                         <input type="text" class="form-control" placeholder="smtp.example.com:25" id="host" required />


### PR DESCRIPTION
This pull request has been opened following the MAIL FROM issues discussed in the #2624 issue. This pull request modifies the html field  `SMTP From` to stop suggesting the users he can add more than one email address. It also implements a check to be sure that the content of the field is an email address by making use of a regex. This modifications also ensures we are complying with [RFC 5321](https://www.ietf.org/rfc/rfc5321.txt)

End users should use the Sender Envelope in the Email template instead.