### PR TITLE
Use location instead of campaign listener URL

### DIFF
--- a/static/js/src/app/campaign_results.js
+++ b/static/js/src/app/campaign_results.js
@@ -933,7 +933,7 @@ function report_mail(rid, cid) {
     }).then(function (result) {
         if (result.value){
             api.campaignId.get(cid).success((function(c) {
-                report_url = new URL(c.url)
+                report_url = new URL(`${location.protocol}//${location.host}`)
                 report_url.pathname = '/report'
                 report_url.search = "?rid=" + rid
                 $.ajax({


### PR DESCRIPTION
The campaign listener URL can be anything (for instance an URL shortener), but when performing an admin function, it should refer to the admin URL itself.

Scenario:
Launch a campaign and set the listener to be https://rebrand.ly/something

Go to the campaign dashboard and try to mark one of the users as if they've reported the campaign.

Expected result:
Result gets reported

Actual result:
Request fails silently with

```
Access to XMLHttpRequest at 'https://rebrand.ly/report?rid=some-id' from origin 'https://yourgophishserver.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```
