### PR TITLE
Add unicode QR code as URL_QR variable in mail template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.5.0
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
-	github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230616071929-fef537719631
+	github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230618192502-f9c05d185bc5
 	github.com/emersion/go-imap v1.0.4
 	github.com/emersion/go-message v0.12.0
 	github.com/go-sql-driver/mysql v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.5.0
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230324202517-0750e1cfc814
 	github.com/emersion/go-imap v1.0.4
 	github.com/emersion/go-message v0.12.0
 	github.com/go-sql-driver/mysql v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.5.0
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
-	github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230324202517-0750e1cfc814
+	github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230616071929-fef537719631
 	github.com/emersion/go-imap v1.0.4
 	github.com/emersion/go-message v0.12.0
 	github.com/go-sql-driver/mysql v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6ROGeiHFAP8WJdI2RoxALQYgdllERc3N5N2DM=
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
+github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230324202517-0750e1cfc814 h1:hpD+/7ob6MgQScaAIGjNoI0qv3YoW39wv/OCh8/XHto=
+github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230324202517-0750e1cfc814/go.mod h1:iolhtalMTUbMmz5vOjYJ2pvJwAhOp4456HwDf77tSeY=
 github.com/emersion/go-imap v1.0.4 h1:uiCAIHM6Z5Jwkma1zdNDWWXxSCqb+/xHBkHflD7XBro=
 github.com/emersion/go-imap v1.0.4/go.mod h1:yKASt+C3ZiDAiCSssxg9caIckWF/JG7ZQTO7GAmvicU=
 github.com/emersion/go-message v0.11.1/go.mod h1:C4jnca5HOTo4bGN9YdqNQM9sITuT3Y0K6bSUw9RklvY=
@@ -78,8 +80,11 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/yeqown/reedsolomon v1.0.0 h1:x1h/Ej/uJnNu8jaX7GLHBWmZKCAWjEJTetkqaabr4B0=
+github.com/yeqown/reedsolomon v1.0.0/go.mod h1:P76zpcn2TCuL0ul1Fso373qHRc69LKwAw/Iy6g1WiiM=
 github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -111,5 +116,6 @@ gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gG
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6RO
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230324202517-0750e1cfc814 h1:hpD+/7ob6MgQScaAIGjNoI0qv3YoW39wv/OCh8/XHto=
 github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230324202517-0750e1cfc814/go.mod h1:iolhtalMTUbMmz5vOjYJ2pvJwAhOp4456HwDf77tSeY=
+github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230616071929-fef537719631 h1:djoC0V0OEE4ngGtifpcw0kA8nZepPcqSCMjV855xVgI=
+github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230616071929-fef537719631/go.mod h1:iolhtalMTUbMmz5vOjYJ2pvJwAhOp4456HwDf77tSeY=
 github.com/emersion/go-imap v1.0.4 h1:uiCAIHM6Z5Jwkma1zdNDWWXxSCqb+/xHBkHflD7XBro=
 github.com/emersion/go-imap v1.0.4/go.mod h1:yKASt+C3ZiDAiCSssxg9caIckWF/JG7ZQTO7GAmvicU=
 github.com/emersion/go-message v0.11.1/go.mod h1:C4jnca5HOTo4bGN9YdqNQM9sITuT3Y0K6bSUw9RklvY=

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230324202517-0750e1cfc814 h1:hpD+/7o
 github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230324202517-0750e1cfc814/go.mod h1:iolhtalMTUbMmz5vOjYJ2pvJwAhOp4456HwDf77tSeY=
 github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230616071929-fef537719631 h1:djoC0V0OEE4ngGtifpcw0kA8nZepPcqSCMjV855xVgI=
 github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230616071929-fef537719631/go.mod h1:iolhtalMTUbMmz5vOjYJ2pvJwAhOp4456HwDf77tSeY=
+github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230618192502-f9c05d185bc5 h1:I2LZvZ95NKONsaOn4+yK3teWtWipMrtrEwqSaAtrXAM=
+github.com/dmarushkin/go-qrcode/v2 v2.0.0-20230618192502-f9c05d185bc5/go.mod h1:iolhtalMTUbMmz5vOjYJ2pvJwAhOp4456HwDf77tSeY=
 github.com/emersion/go-imap v1.0.4 h1:uiCAIHM6Z5Jwkma1zdNDWWXxSCqb+/xHBkHflD7XBro=
 github.com/emersion/go-imap v1.0.4/go.mod h1:yKASt+C3ZiDAiCSssxg9caIckWF/JG7ZQTO7GAmvicU=
 github.com/emersion/go-message v0.11.1/go.mod h1:C4jnca5HOTo4bGN9YdqNQM9sITuT3Y0K6bSUw9RklvY=

--- a/models/template_context.go
+++ b/models/template_context.go
@@ -61,7 +61,7 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 	phishURL.RawQuery = q.Encode()
 
 	qrc, _ := qrcode.New(phishURL.String())
-	url_qr := qrc.GetUnicodeStr()
+	url_qr := qrc.GetHtmlStr()
 
 	trackingURL, _ := url.Parse(templateURL)
 	trackingURL.Path = path.Join(trackingURL.Path, "/track")

--- a/models/template_context.go
+++ b/models/template_context.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"path"
 	"text/template"
+
+	"github.com/dmarushkin/go-qrcode/v2"
 )
 
 // TemplateContext is an interface that allows both campaigns and email
@@ -20,6 +22,7 @@ type TemplateContext interface {
 type PhishingTemplateContext struct {
 	From        string
 	URL         string
+	URL_QR      string
 	Tracker     string
 	TrackingURL string
 	RId         string
@@ -57,6 +60,9 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 	q.Set(RecipientParameter, rid)
 	phishURL.RawQuery = q.Encode()
 
+	qrc, _ := qrcode.New(phishURL.String())
+	url_qr := qrc.GetUnicodeStr()
+
 	trackingURL, _ := url.Parse(templateURL)
 	trackingURL.Path = path.Join(trackingURL.Path, "/track")
 	trackingURL.RawQuery = q.Encode()
@@ -65,6 +71,7 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 		BaseRecipient: r,
 		BaseURL:       baseURL.String(),
 		URL:           phishURL.String(),
+		URL_QR:        url_qr,
 		TrackingURL:   trackingURL.String(),
 		Tracker:       "<img alt='' style='display: none' src='" + trackingURL.String() + "'/>",
 		From:          fn,

--- a/models/template_context_test.go
+++ b/models/template_context_test.go
@@ -36,7 +36,7 @@ func (s *ModelsSuite) TestNewTemplateContext(c *check.C) {
 	}
 
 	qrc, _ := qrcode.New(fmt.Sprintf("%s?rid=%s", ctx.URL, r.RId))
-	url_qr := qrc.GetUnicodeStr()
+	url_qr := qrc.GetHtmlStr()
 
 	expected := PhishingTemplateContext{
 		URL:           fmt.Sprintf("%s?rid=%s", ctx.URL, r.RId),

--- a/models/template_context_test.go
+++ b/models/template_context_test.go
@@ -3,6 +3,8 @@ package models
 import (
 	"fmt"
 
+	"github.com/dmarushkin/go-qrcode/v2"
+
 	check "gopkg.in/check.v1"
 )
 
@@ -32,14 +34,20 @@ func (s *ModelsSuite) TestNewTemplateContext(c *check.C) {
 		URL:         "http://example.com",
 		FromAddress: "From Address <from@example.com>",
 	}
+
+	qrc, _ := qrcode.New(fmt.Sprintf("%s?rid=%s", ctx.URL, r.RId))
+	url_qr := qrc.GetUnicodeStr()
+
 	expected := PhishingTemplateContext{
 		URL:           fmt.Sprintf("%s?rid=%s", ctx.URL, r.RId),
+		URL_QR:        url_qr,
 		BaseURL:       ctx.URL,
 		BaseRecipient: r.BaseRecipient,
 		TrackingURL:   fmt.Sprintf("%s/track?rid=%s", ctx.URL, r.RId),
 		From:          "From Address",
 		RId:           r.RId,
 	}
+
 	expected.Tracker = "<img alt='' style='display: none' src='" + expected.TrackingURL + "'/>"
 	got, err := NewPhishingTemplateContext(ctx, r.BaseRecipient, r.RId)
 	c.Assert(err, check.Equals, nil)


### PR DESCRIPTION
Hi team!

Please consider small change that add ability to add in email template text unicode QR code instead of URL in clear text.

It inspired by this thread https://stackoverflow.com/questions/19673303/formatting-qr-codes-in-html-emails-using-the-pre-tag/75771797 and tested in assessment with "Check our new mobile ChatGPT Internal Support Bot in Telegram" scenario, where internal outlook blocked external image link with QR.

Best regards and thanks for great app!