### PR TITLE
Docker: move database to a directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,9 @@ RUN setcap 'cap_net_bind_service=+ep' /opt/gophish/gophish
 
 USER app
 RUN sed -i 's/127.0.0.1/0.0.0.0/g' config.json
+RUN sed -i 's/"gophish.db"/"data\/gophish.db"/g' config.json
 RUN touch config.json.tmp
+RUN mkdir data
 
 EXPOSE 3333 8080 8443 80
 


### PR DESCRIPTION
This makes a minor change to the Dockerfile to change the default location of the Gophish database within the docker container to be in its own directory (./data/). This would allow for that directory to be bind mounted making it easier to persist the database over container restarts. Attempting to bind mount just the database file is problematic if the file doesn't yet exist, as Docker will create a directory instead of the file and Gophish won't be able to create the database file.

This should help to address issues that are brought up periodically regarding database persistence in Docker (e.g. #2764 #1969 #2416)