### PR TITLE
Addition to docker run.sh

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -66,6 +66,13 @@ if [ -n "${CONTACT_ADDRESS+set}" ] ; then
         cat config.json.tmp > config.json
 fi
 
+if [ -n "${DB_NAME+set}" ] ; then
+    jq -r \
+        --arg DB_NAME "${DB_NAME}" \
+        '.db_name = $DB_NAME' config.json > config.json.tmp && \
+        cat config.json.tmp > config.json
+fi
+
 if [ -n "${DB_FILE_PATH+set}" ] ; then
     jq -r \
         --arg DB_FILE_PATH "${DB_FILE_PATH}" \


### PR DESCRIPTION
Added db_name to run.sh in order to be able to switch to mysql via env var. This is needed because I run the docker-container in an evironment which needs the config to be set via environment and I, of course ;), want to use mysql for production.