### PR TITLE
Install ca-certificates on Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM debian:stable-slim
 RUN useradd -m -d /opt/gophish -s /bin/bash app
 
 RUN apt-get update && \
-	apt-get install --no-install-recommends -y jq libcap2-bin && \
+	apt-get install --no-install-recommends -y jq libcap2-bin ca-certificates && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
The `ca-certificates` package is necessary for Gophish to connect to webhooks using HTTPS.

Without this package, when trying to ping an HTTPS webhook, Gophish prints the following error:
`Ping of "$name" webhook failed: "Post" "https://example.com/webhook": x509: certificate signed by unknown authority`