### PR TITLE
Set user last_login time for right mysql working

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -212,6 +212,7 @@ func Setup(c *config.Config) error {
 			Role:                   adminRole,
 			RoleID:                 adminRole.ID,
 			PasswordChangeRequired: true,
+			LastLogin:              time.Now().UTC(),
 		}
 
 		if envToken := os.Getenv(InitialAdminApiToken); envToken != "" {


### PR DESCRIPTION
While using mysql as default database backend fails with error `Incorrect datetime value: '0000-00-00' for column 'last_login' at row 1"`, there is solution for this error