### PR TITLE
feat: allow uniq identifier into phish url

### DIFF
--- a/models/email_request.go
+++ b/models/email_request.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"net/mail"
+	"strings"
 
 	"github.com/gophish/gomail"
 	"github.com/gophish/gophish/config"
@@ -35,7 +36,7 @@ type EmailRequest struct {
 }
 
 func (s *EmailRequest) getBaseURL() string {
-	return s.URL
+	return strings.Replace(s.URL, "*", s.RId, -1)
 }
 
 func (s *EmailRequest) getFromAddress() string {

--- a/models/template_context.go
+++ b/models/template_context.go
@@ -5,6 +5,7 @@ import (
 	"net/mail"
 	"net/url"
 	"path"
+	"strings"
 	"text/template"
 )
 
@@ -38,6 +39,7 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 	if fn == "" {
 		fn = f.Address
 	}
+
 	templateURL, err := ExecuteTemplate(ctx.getBaseURL(), r)
 	if err != nil {
 		return PhishingTemplateContext{}, err
@@ -52,7 +54,7 @@ func NewPhishingTemplateContext(ctx TemplateContext, r BaseRecipient, rid string
 	baseURL.Path = ""
 	baseURL.RawQuery = ""
 
-	phishURL, _ := url.Parse(templateURL)
+	phishURL, _ := url.Parse(strings.Replace(templateURL, "*", rid, -1))
 	q := phishURL.Query()
 	q.Set(RecipientParameter, rid)
 	phishURL.RawQuery = q.Encode()

--- a/models/template_context_test.go
+++ b/models/template_context_test.go
@@ -45,3 +45,30 @@ func (s *ModelsSuite) TestNewTemplateContext(c *check.C) {
 	c.Assert(err, check.Equals, nil)
 	c.Assert(got, check.DeepEquals, expected)
 }
+
+func (s *ModelsSuite) TestNewTemplateContextWithWildcard(c *check.C) {
+	r := Result{
+		BaseRecipient: BaseRecipient{
+			FirstName: "Foo",
+			LastName:  "Bar",
+			Email:     "foo@bar.com",
+		},
+		RId: "1234567",
+	}
+	ctx := mockTemplateContext{
+		URL:         "http://*.example.com",
+		FromAddress: "From Address <from@example.com>",
+	}
+	expected := PhishingTemplateContext{
+		URL:           fmt.Sprintf("http://%s.example.com?rid=%s",r.RId, r.RId),
+		BaseURL:       ctx.URL,
+		BaseRecipient: r.BaseRecipient,
+		TrackingURL:   fmt.Sprintf("%s/track?rid=%s", ctx.URL, r.RId),
+		From:          "From Address",
+		RId:           r.RId,
+	}
+	expected.Tracker = "<img alt='' style='display: none' src='" + expected.TrackingURL + "'/>"
+	got, err := NewPhishingTemplateContext(ctx, r.BaseRecipient, r.RId)
+	c.Assert(err, check.Equals, nil)
+	c.Assert(got, check.DeepEquals, expected)
+}

--- a/templates/campaigns.html
+++ b/templates/campaigns.html
@@ -96,7 +96,7 @@
                     <option></option>
                     </select>
                     <label class="control-label" for="url">URL:
-                        <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="Location of Gophish listener (must be reachable by targets!)"></i>
+                        <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="Location of Gophish listener (must be reachable by targets!), add * in url to replace by uniq identifier"></i>
                     </label>
                     <input type="text" class="form-control" placeholder="http://192.168.1.1" id="url" />
                     <div class="row">


### PR DESCRIPTION
This PR is for isse #2978 

When set * into URL, it will be replace by RId in order to avoid google URL protection.