### PR TITLE
Add support for HTTP_PROXY into the import functionality

### DIFF
--- a/controllers/api/import.go
+++ b/controllers/api/import.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -115,12 +117,27 @@ func (as *Server) ImportSite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	restrictedDialer := dialer.Dialer()
-	tr := &http.Transport{
-		DialContext: restrictedDialer.DialContext,
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+	var tr *http.Transport
+	if os.Getenv("HTTP_PROXY") != "" {
+		proxyURL, err := url.Parse(os.Getenv("HTTP_PROXY"))
+		if err == nil {
+			tr = &http.Transport{
+				DialContext: restrictedDialer.DialContext,
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				Proxy: http.ProxyURL(proxyURL),
+			}
+		} else {
+			tr = &http.Transport{
+				DialContext: restrictedDialer.DialContext,
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			}
+		}
 	}
+
 	client := &http.Client{Transport: tr}
 	resp, err := client.Get(cr.URL)
 	if err != nil {


### PR DESCRIPTION
As noted in #212 import functionality fails when an egress proxy is in use, this pull requests addresses this by adding in support for detection of an environment variable `HTTP_PROXY` if this is detected this value will be used as a HTTP proxy.