### PR TITLE
last_activity user field (New functionality)

### DIFF
--- a/controllers/api/user.go
+++ b/controllers/api/user.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gophish/gophish/auth"
 	ctx "github.com/gophish/gophish/context"
@@ -29,11 +30,12 @@ var ErrInsufficientPermission = errors.New("Permission denied")
 
 // userRequest is the payload which represents the creation of a new user.
 type userRequest struct {
-	Username               string `json:"username"`
-	Password               string `json:"password"`
-	Role                   string `json:"role"`
-	PasswordChangeRequired bool   `json:"password_change_required"`
-	AccountLocked          bool   `json:"account_locked"`
+	Username               string    `json:"username"`
+	Password               string    `json:"password"`
+	Role                   string    `json:"role"`
+	PasswordChangeRequired bool      `json:"password_change_required"`
+	AccountLocked          bool      `json:"account_locked"`
+	LastActivity           time.Time `json:"last_acitvity"`
 }
 
 func (ur *userRequest) Validate(existingUser *models.User) error {
@@ -109,7 +111,9 @@ func (as *Server) Users(w http.ResponseWriter, r *http.Request) {
 			Role:                   role,
 			RoleID:                 role.ID,
 			PasswordChangeRequired: ur.PasswordChangeRequired,
+			LastActivity 			ur.LastActivity,
 		}
+		
 		err = models.PutUser(&user)
 		if err != nil {
 			JSONResponse(w, models.Response{Success: false, Message: err.Error()}, http.StatusInternalServerError)

--- a/controllers/route.go
+++ b/controllers/route.go
@@ -123,6 +123,7 @@ func (as *AdminServer) Shutdown() error {
 func (as *AdminServer) registerRoutes() {
 	router := mux.NewRouter()
 	// Base Front-end routes
+	router.Use(mid.UserActivityHandler)
 	router.HandleFunc("/", mid.Use(as.Base, mid.RequireLogin))
 	router.HandleFunc("/login", mid.Use(as.Login, as.limiter.Limit))
 	router.HandleFunc("/logout", mid.Use(as.Logout, mid.RequireLogin))

--- a/db/db_mysql/migrations/20230123084327_user_lastactivity.sql
+++ b/db/db_mysql/migrations/20230123084327_user_lastactivity.sql
@@ -1,0 +1,9 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE `users`
+ADD COLUMN `last_acitivty` DATETIME NULL;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+

--- a/db/db_sqlite3/migrations/20230123084327_user_lastactivity.sql
+++ b/db/db_sqlite3/migrations/20230123084327_user_lastactivity.sql
@@ -1,0 +1,9 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE `users`
+ADD COLUMN `last_acitivty` DATETIME NULL;
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+

--- a/models/user.go
+++ b/models/user.go
@@ -23,6 +23,7 @@ type User struct {
 	PasswordChangeRequired bool      `json:"password_change_required"`
 	AccountLocked          bool      `json:"account_locked"`
 	LastLogin              time.Time `json:"last_login"`
+	LastActivity           time.Time `json:"last_activity"`
 }
 
 // GetUser returns the user that the given id corresponds to. If no user is found, an


### PR DESCRIPTION
Added a new field for users called last_activity so we can track user's activity.
The field is not being shown in the gophish interfaces, used for API/Requests purposes to check user's activity.
Use case:
Using API or Requests:
Check if any user is online by checking if an user has done any actions in the past 20 minutes for example.
Check if the user is actively using GoPhish.