### PR TITLE
Update documentation to match  /campaigns/:id/complete endpoint method

### DIFF
--- a/static/js/src/app/gophish.js
+++ b/static/js/src/app/gophish.js
@@ -100,7 +100,7 @@ var api = {
         results: function (id) {
             return query("/campaigns/" + id + "/results", "GET", {}, true)
         },
-        // complete() - Completes a campaign at POST /campaigns/:id/complete
+        // complete() - Completes a campaign at GET /campaigns/:id/complete
         complete: function (id) {
             return query("/campaigns/" + id + "/complete", "GET", {}, true)
         },


### PR DESCRIPTION
Regarding issue 3117, I tested the endpoint to make sure it was working, and it was working to complete a campaign via GET  /campaigns/:id/complete. I just changed comment to match the method.

closes #3117