### PR TITLE
feat(server)!: the endpoint complete campaigns is switched to the post method

### DIFF
--- a/controllers/api/campaign.go
+++ b/controllers/api/campaign.go
@@ -126,7 +126,7 @@ func (as *Server) CampaignComplete(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id, _ := strconv.ParseInt(vars["id"], 0, 64)
 	switch {
-	case r.Method == "GET":
+	case r.Method == "POST" || r.Method == "GET":
 		err := models.CompleteCampaign(id, ctx.Get(r, "user_id").(int64))
 		if err != nil {
 			JSONResponse(w, models.Response{Success: false, Message: "Error completing campaign"}, http.StatusInternalServerError)

--- a/static/js/src/app/gophish.js
+++ b/static/js/src/app/gophish.js
@@ -102,7 +102,7 @@ var api = {
         },
         // complete() - Completes a campaign at POST /campaigns/:id/complete
         complete: function (id) {
-            return query("/campaigns/" + id + "/complete", "GET", {}, true)
+            return query("/campaigns/" + id + "/complete", "POST", {}, true)
         },
         // summary() - Queries the API for GET /campaigns/summary
         summary: function (id) {


### PR DESCRIPTION
## Reason
Solve problem [3117](https://github.com/gophish/gophish/issues/3117) which is to change the endpoint from GET to POST of the route that completes the campaign 

## Changes
* `controllers/api/campaign.go`:  Changed the enpoint method from POST to GET   in  `campaigns/{id:[0-9]+}/complete`
* `static/js/src/app/gophish.js`:  Changed the enpoint method from POST to GET   in `query("/campaigns/" + id + "/complete", "POST", {}, true)`

* Compiled the corresponding JavaScript with Gulp (static/js/dist/app/autocomplete.min.js, static/js/dist/app/campaign_results.min.js, static/js/dist/app/settings.min.js...)